### PR TITLE
Add Markdown rendering widgets and builders

### DIFF
--- a/lib/flutter_smooth_markdown.dart
+++ b/lib/flutter_smooth_markdown.dart
@@ -11,9 +11,12 @@ export 'src/parser/ast/markdown_node.dart';
 // Export parser
 export 'src/parser/markdown_parser.dart';
 
-// TODO: Export widgets when implemented
-// export 'widgets/smooth_markdown.dart';
-// export 'widgets/smooth_markdown_stream.dart';
+// Export renderer
+export 'src/renderer/markdown_renderer.dart';
+export 'src/renderer/widget_builder.dart';
 
-// TODO: Export renderer when implemented
-// export 'src/renderer/markdown_renderer.dart';
+// Export widgets
+export 'widgets/smooth_markdown.dart';
+
+// TODO: Export streaming widget when implemented
+// export 'widgets/smooth_markdown_stream.dart';

--- a/lib/src/config/markdown_config.dart
+++ b/lib/src/config/markdown_config.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/widgets.dart';
+
 /// Configuration options for Markdown parsing and rendering
 class MarkdownConfig {
   /// Creates a new Markdown configuration
@@ -111,7 +113,3 @@ class MarkdownConfig {
       'enableLatex: $enableLatex, '
       'syntaxHighlightTheme: $syntaxHighlightTheme)';
 }
-
-// Placeholder type for Widget - will be replaced with actual import
-typedef Widget = dynamic;
-typedef BuildContext = dynamic;

--- a/lib/src/parser/block_parser.dart
+++ b/lib/src/parser/block_parser.dart
@@ -71,9 +71,7 @@ class BlockParser {
         consumed = result.linesConsumed;
       }
 
-      if (node != null) {
-        nodes.add(node);
-      }
+      nodes.add(node);
       i += consumed > 0 ? consumed : 1;
     }
 

--- a/lib/src/parser/inline_parser.dart
+++ b/lib/src/parser/inline_parser.dart
@@ -128,7 +128,7 @@ class InlineParser {
     }
 
     // Find closing )
-    var urlStart = altEnd + 2;
+    final urlStart = altEnd + 2;
     var urlEnd = -1;
     i = urlStart;
     while (i < text.length) {
@@ -182,7 +182,7 @@ class InlineParser {
     }
 
     // Find closing )
-    var urlStart = textEnd + 2;
+    final urlStart = textEnd + 2;
     var urlEnd = -1;
     i = urlStart;
     while (i < text.length) {

--- a/lib/src/renderer/builders/blockquote_builder.dart
+++ b/lib/src/renderer/builders/blockquote_builder.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+import '../../config/style_sheet.dart';
+import '../../parser/ast/markdown_node.dart';
+import '../markdown_renderer.dart';
+import '../widget_builder.dart';
+
+/// Builder for blockquote nodes
+class BlockquoteBuilder extends MarkdownWidgetBuilder {
+  /// Creates a new blockquote builder
+  const BlockquoteBuilder();
+
+  @override
+  bool canBuild(MarkdownNode node) => node is BlockquoteNode;
+
+  @override
+  Widget build(
+    MarkdownNode node,
+    MarkdownStyleSheet styleSheet,
+    MarkdownRenderContext context,
+  ) {
+    final quoteNode = node as BlockquoteNode;
+    final renderer = MarkdownRenderer(styleSheet: styleSheet);
+
+    return Container(
+      decoration: styleSheet.blockquoteDecoration,
+      padding: styleSheet.blockquotePadding,
+      child: renderer.render(quoteNode.children, context: context),
+    );
+  }
+}

--- a/lib/src/renderer/builders/code_block_builder.dart
+++ b/lib/src/renderer/builders/code_block_builder.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+import '../../config/style_sheet.dart';
+import '../../parser/ast/markdown_node.dart';
+import '../widget_builder.dart';
+
+/// Builder for code block nodes
+class CodeBlockBuilder extends MarkdownWidgetBuilder {
+  /// Creates a new code block builder
+  const CodeBlockBuilder();
+
+  @override
+  bool canBuild(MarkdownNode node) => node is CodeBlockNode;
+
+  @override
+  Widget build(
+    MarkdownNode node,
+    MarkdownStyleSheet styleSheet,
+    MarkdownRenderContext context,
+  ) {
+    final codeBlockNode = node as CodeBlockNode;
+
+    // Use custom builder if provided
+    if (context.codeBuilder != null) {
+      return context.codeBuilder!(
+        codeBlockNode.code,
+        codeBlockNode.language,
+      );
+    }
+
+    // Default rendering
+    return Container(
+      decoration: styleSheet.codeBlockDecoration,
+      padding: styleSheet.codeBlockPadding,
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Text(
+          codeBlockNode.code,
+          style: styleSheet.codeBlockStyle,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/renderer/builders/header_builder.dart
+++ b/lib/src/renderer/builders/header_builder.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/widgets.dart';
+
+import '../../config/style_sheet.dart';
+import '../../parser/ast/markdown_node.dart';
+import '../widget_builder.dart';
+
+/// Builder for header nodes (H1-H6)
+class HeaderBuilder extends MarkdownWidgetBuilder {
+  /// Creates a new header builder
+  const HeaderBuilder();
+
+  @override
+  bool canBuild(MarkdownNode node) => node is HeaderNode;
+
+  @override
+  Widget build(
+    MarkdownNode node,
+    MarkdownStyleSheet styleSheet,
+    MarkdownRenderContext context,
+  ) {
+    final headerNode = node as HeaderNode;
+
+    final style = _getHeaderStyle(headerNode.level, styleSheet);
+
+    return Text(
+      headerNode.content,
+      style: style,
+    );
+  }
+
+  TextStyle? _getHeaderStyle(int level, MarkdownStyleSheet styleSheet) {
+    switch (level) {
+      case 1:
+        return styleSheet.h1Style;
+      case 2:
+        return styleSheet.h2Style;
+      case 3:
+        return styleSheet.h3Style;
+      case 4:
+        return styleSheet.h4Style;
+      case 5:
+        return styleSheet.h5Style;
+      case 6:
+        return styleSheet.h6Style;
+      default:
+        return styleSheet.textStyle;
+    }
+  }
+}

--- a/lib/src/renderer/builders/horizontal_rule_builder.dart
+++ b/lib/src/renderer/builders/horizontal_rule_builder.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+import '../../config/style_sheet.dart';
+import '../../parser/ast/markdown_node.dart';
+import '../widget_builder.dart';
+
+/// Builder for horizontal rule nodes
+class HorizontalRuleBuilder extends MarkdownWidgetBuilder {
+  /// Creates a new horizontal rule builder
+  const HorizontalRuleBuilder();
+
+  @override
+  bool canBuild(MarkdownNode node) => node is HorizontalRuleNode;
+
+  @override
+  Widget build(
+    MarkdownNode node,
+    MarkdownStyleSheet styleSheet,
+    MarkdownRenderContext context,
+  ) {
+    return Container(
+      height: styleSheet.horizontalRuleThickness ?? 1.0,
+      color: styleSheet.horizontalRuleColor ?? Colors.grey[400],
+    );
+  }
+}

--- a/lib/src/renderer/builders/image_builder.dart
+++ b/lib/src/renderer/builders/image_builder.dart
@@ -1,0 +1,53 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+import '../../config/style_sheet.dart';
+import '../../parser/ast/markdown_node.dart';
+import '../widget_builder.dart';
+
+/// Builder for image nodes
+class ImageBuilder extends MarkdownWidgetBuilder {
+  /// Creates a new image builder
+  const ImageBuilder();
+
+  @override
+  bool canBuild(MarkdownNode node) => node is ImageNode;
+
+  @override
+  Widget build(
+    MarkdownNode node,
+    MarkdownStyleSheet styleSheet,
+    MarkdownRenderContext context,
+  ) {
+    final imageNode = node as ImageNode;
+
+    // Use custom builder if provided
+    if (context.imageBuilder != null) {
+      return context.imageBuilder!(
+        imageNode.url,
+        imageNode.alt,
+        imageNode.title,
+      );
+    }
+
+    // Default rendering with caching
+    if (imageNode.url.startsWith('http://') ||
+        imageNode.url.startsWith('https://')) {
+      return CachedNetworkImage(
+        imageUrl: imageNode.url,
+        placeholder: (context, url) => const Center(
+          child: CircularProgressIndicator(),
+        ),
+        errorWidget: (context, url, error) => const Icon(Icons.error),
+      );
+    }
+
+    // Local image
+    return Image.asset(
+      imageNode.url,
+      errorBuilder: (context, error, stackTrace) {
+        return const Icon(Icons.broken_image);
+      },
+    );
+  }
+}

--- a/lib/src/renderer/builders/inline_code_builder.dart
+++ b/lib/src/renderer/builders/inline_code_builder.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/widgets.dart';
+
+import '../../config/style_sheet.dart';
+import '../../parser/ast/markdown_node.dart';
+import '../widget_builder.dart';
+
+/// Builder for inline code nodes
+class InlineCodeBuilder extends MarkdownWidgetBuilder {
+  /// Creates a new inline code builder
+  const InlineCodeBuilder();
+
+  @override
+  bool canBuild(MarkdownNode node) => node is InlineCodeNode;
+
+  @override
+  Widget build(
+    MarkdownNode node,
+    MarkdownStyleSheet styleSheet,
+    MarkdownRenderContext context,
+  ) {
+    final codeNode = node as InlineCodeNode;
+
+    return Text(
+      codeNode.code,
+      style: styleSheet.inlineCodeStyle,
+    );
+  }
+}

--- a/lib/src/renderer/builders/link_builder.dart
+++ b/lib/src/renderer/builders/link_builder.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+import '../../config/style_sheet.dart';
+import '../../parser/ast/markdown_node.dart';
+import '../markdown_renderer.dart';
+import '../widget_builder.dart';
+
+/// Builder for link nodes
+class LinkBuilder extends MarkdownWidgetBuilder {
+  /// Creates a new link builder
+  const LinkBuilder();
+
+  @override
+  bool canBuild(MarkdownNode node) => node is LinkNode;
+
+  @override
+  Widget build(
+    MarkdownNode node,
+    MarkdownStyleSheet styleSheet,
+    MarkdownRenderContext context,
+  ) {
+    final linkNode = node as LinkNode;
+    final renderer = MarkdownRenderer(styleSheet: styleSheet);
+
+    // Render link text with link style
+    final linkWidget = renderer.renderInline(
+      linkNode.children,
+      styleSheet.linkStyle,
+      context,
+    );
+
+    // Wrap in GestureDetector for tap handling
+    return GestureDetector(
+      onTap: () {
+        context.onTapLink?.call(linkNode.url);
+      },
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: linkWidget,
+      ),
+    );
+  }
+}

--- a/lib/src/renderer/builders/list_builder.dart
+++ b/lib/src/renderer/builders/list_builder.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+
+import '../../config/style_sheet.dart';
+import '../../parser/ast/markdown_node.dart';
+import '../markdown_renderer.dart';
+import '../widget_builder.dart';
+
+/// Builder for list nodes
+class ListBuilder extends MarkdownWidgetBuilder {
+  /// Creates a new list builder
+  const ListBuilder();
+
+  @override
+  bool canBuild(MarkdownNode node) => node is ListNode;
+
+  @override
+  Widget build(
+    MarkdownNode node,
+    MarkdownStyleSheet styleSheet,
+    MarkdownRenderContext context,
+  ) {
+    final listNode = node as ListNode;
+    final renderer = MarkdownRenderer(styleSheet: styleSheet);
+    final indent = styleSheet.listIndent ?? 24.0;
+
+    final listItems = <Widget>[];
+    for (var i = 0; i < listNode.items.length; i++) {
+      final item = listNode.items[i];
+      final index = listNode.ordered ? listNode.startIndex + i : null;
+
+      listItems.add(
+        _buildListItem(
+          item,
+          index,
+          indent,
+          renderer,
+          styleSheet,
+          context,
+        ),
+      );
+    }
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: listItems,
+    );
+  }
+
+  Widget _buildListItem(
+    ListItemNode item,
+    int? index,
+    double indent,
+    MarkdownRenderer renderer,
+    MarkdownStyleSheet styleSheet,
+    MarkdownRenderContext context,
+  ) {
+    // Build marker (bullet or number)
+    Widget marker;
+    if (item.checked != null) {
+      // Task list item
+      marker = Icon(
+        item.checked! ? Icons.check_box : Icons.check_box_outline_blank,
+        size: 20,
+      );
+    } else if (index != null) {
+      // Ordered list
+      marker = Text(
+        '$index. ',
+        style: styleSheet.listBulletStyle,
+      );
+    } else {
+      // Unordered list
+      marker = Text(
+        '• ',
+        style: styleSheet.listBulletStyle,
+      );
+    }
+
+    // Render item content
+    final content = renderer.renderInline(
+      item.children,
+      styleSheet.textStyle,
+      context,
+    );
+
+    return Padding(
+      padding: EdgeInsets.only(left: context.listLevel * indent),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          marker,
+          const SizedBox(width: 4),
+          Expanded(child: content),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/renderer/builders/paragraph_builder.dart
+++ b/lib/src/renderer/builders/paragraph_builder.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/widgets.dart';
+
+import '../../config/style_sheet.dart';
+import '../../parser/ast/markdown_node.dart';
+import '../markdown_renderer.dart';
+import '../widget_builder.dart';
+
+/// Builder for paragraph nodes
+class ParagraphBuilder extends MarkdownWidgetBuilder {
+  /// Creates a new paragraph builder
+  const ParagraphBuilder();
+
+  @override
+  bool canBuild(MarkdownNode node) => node is ParagraphNode;
+
+  @override
+  Widget build(
+    MarkdownNode node,
+    MarkdownStyleSheet styleSheet,
+    MarkdownRenderContext context,
+  ) {
+    final paragraphNode = node as ParagraphNode;
+
+    // Create a temporary renderer to render inline content
+    final renderer = MarkdownRenderer(styleSheet: styleSheet);
+
+    return renderer.renderInline(
+      paragraphNode.children,
+      styleSheet.paragraphStyle,
+      context,
+    );
+  }
+}

--- a/lib/src/renderer/builders/text_builder.dart
+++ b/lib/src/renderer/builders/text_builder.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/widgets.dart';
+
+import '../../config/style_sheet.dart';
+import '../../parser/ast/markdown_node.dart';
+import '../widget_builder.dart';
+
+/// Builder for text nodes
+class TextBuilder extends MarkdownWidgetBuilder {
+  /// Creates a new text builder
+  const TextBuilder();
+
+  @override
+  bool canBuild(MarkdownNode node) => node is TextNode;
+
+  @override
+  Widget build(
+    MarkdownNode node,
+    MarkdownStyleSheet styleSheet,
+    MarkdownRenderContext context,
+  ) {
+    final textNode = node as TextNode;
+
+    return Text(
+      textNode.content,
+      style: styleSheet.textStyle,
+    );
+  }
+}

--- a/lib/src/renderer/builders/text_style_builder.dart
+++ b/lib/src/renderer/builders/text_style_builder.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/widgets.dart';
+
+import '../../config/style_sheet.dart';
+import '../../parser/ast/markdown_node.dart';
+import '../markdown_renderer.dart';
+import '../widget_builder.dart';
+
+/// Builder for bold text nodes
+class BoldBuilder extends MarkdownWidgetBuilder {
+  /// Creates a new bold builder
+  const BoldBuilder();
+
+  @override
+  bool canBuild(MarkdownNode node) => node is BoldNode;
+
+  @override
+  Widget build(
+    MarkdownNode node,
+    MarkdownStyleSheet styleSheet,
+    MarkdownRenderContext context,
+  ) {
+    final boldNode = node as BoldNode;
+    final renderer = MarkdownRenderer(styleSheet: styleSheet);
+
+    return renderer.renderInline(
+      boldNode.children,
+      styleSheet.boldStyle,
+      context,
+    );
+  }
+}
+
+/// Builder for italic text nodes
+class ItalicBuilder extends MarkdownWidgetBuilder {
+  /// Creates a new italic builder
+  const ItalicBuilder();
+
+  @override
+  bool canBuild(MarkdownNode node) => node is ItalicNode;
+
+  @override
+  Widget build(
+    MarkdownNode node,
+    MarkdownStyleSheet styleSheet,
+    MarkdownRenderContext context,
+  ) {
+    final italicNode = node as ItalicNode;
+    final renderer = MarkdownRenderer(styleSheet: styleSheet);
+
+    return renderer.renderInline(
+      italicNode.children,
+      styleSheet.italicStyle,
+      context,
+    );
+  }
+}
+
+/// Builder for strikethrough text nodes
+class StrikethroughBuilder extends MarkdownWidgetBuilder {
+  /// Creates a new strikethrough builder
+  const StrikethroughBuilder();
+
+  @override
+  bool canBuild(MarkdownNode node) => node is StrikethroughNode;
+
+  @override
+  Widget build(
+    MarkdownNode node,
+    MarkdownStyleSheet styleSheet,
+    MarkdownRenderContext context,
+  ) {
+    final strikeNode = node as StrikethroughNode;
+    final renderer = MarkdownRenderer(styleSheet: styleSheet);
+
+    return renderer.renderInline(
+      strikeNode.children,
+      styleSheet.strikethroughStyle,
+      context,
+    );
+  }
+}

--- a/lib/src/renderer/markdown_renderer.dart
+++ b/lib/src/renderer/markdown_renderer.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/widgets.dart';
+
+import '../config/style_sheet.dart';
+import '../parser/ast/markdown_node.dart';
+import 'builders/blockquote_builder.dart';
+import 'builders/code_block_builder.dart';
+import 'builders/header_builder.dart';
+import 'builders/horizontal_rule_builder.dart';
+import 'builders/image_builder.dart';
+import 'builders/inline_code_builder.dart';
+import 'builders/link_builder.dart';
+import 'builders/list_builder.dart';
+import 'builders/paragraph_builder.dart';
+import 'builders/text_builder.dart';
+import 'builders/text_style_builder.dart';
+import 'widget_builder.dart';
+
+/// Main renderer that converts Markdown AST nodes to Flutter widgets
+class MarkdownRenderer {
+  /// Creates a new Markdown renderer
+  MarkdownRenderer({
+    MarkdownStyleSheet? styleSheet,
+    BuilderRegistry? builderRegistry,
+  })  : styleSheet = styleSheet ?? MarkdownStyleSheet.light(),
+        _builderRegistry = builderRegistry ?? _createDefaultRegistry();
+
+  /// The style sheet to use for rendering
+  final MarkdownStyleSheet styleSheet;
+
+  /// The builder registry
+  final BuilderRegistry _builderRegistry;
+
+  /// Creates the default builder registry
+  static BuilderRegistry _createDefaultRegistry() {
+    return BuilderRegistry()
+      ..register('text', const TextBuilder())
+      ..register('header', const HeaderBuilder())
+      ..register('paragraph', const ParagraphBuilder())
+      ..register('code_block', const CodeBlockBuilder())
+      ..register('blockquote', const BlockquoteBuilder())
+      ..register('list', const ListBuilder())
+      ..register('horizontal_rule', const HorizontalRuleBuilder())
+      ..register('inline_code', const InlineCodeBuilder())
+      ..register('bold', const BoldBuilder())
+      ..register('italic', const ItalicBuilder())
+      ..register('strikethrough', const StrikethroughBuilder())
+      ..register('link', const LinkBuilder())
+      ..register('image', const ImageBuilder());
+  }
+
+  /// Renders a list of Markdown nodes to a widget
+  Widget render(
+    List<MarkdownNode> nodes, {
+    MarkdownRenderContext? context,
+  }) {
+    final renderContext = context ?? const MarkdownRenderContext();
+
+    final widgets = nodes
+        .map((node) => _renderNode(node, renderContext))
+        .where((widget) => widget != null)
+        .cast<Widget>()
+        .toList();
+
+    if (widgets.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: _addSpacing(widgets),
+    );
+  }
+
+  /// Renders a single node
+  Widget? _renderNode(MarkdownNode node, MarkdownRenderContext context) {
+    final builder = _builderRegistry.findBuilder(node);
+
+    if (builder == null) {
+      // Fallback for unknown node types
+      return Text('Unknown node type: ${node.type}');
+    }
+
+    return builder.build(node, styleSheet, context);
+  }
+
+  /// Renders inline nodes (used by builders)
+  Widget renderInline(
+    List<MarkdownNode> nodes,
+    TextStyle? baseStyle,
+    MarkdownRenderContext context,
+  ) {
+    if (nodes.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final spans = nodes.map((node) {
+      final builder = _builderRegistry.findBuilder(node);
+      if (builder == null) {
+        return TextSpan(text: 'Unknown: ${node.type}');
+      }
+
+      final widget = builder.build(node, styleSheet, context);
+
+      // If it's a text-based node, extract the TextSpan
+      if (widget is Text) {
+        return widget.textSpan ?? TextSpan(text: widget.data);
+      } else if (widget is RichText) {
+        return widget.text;
+      }
+
+      // For non-text widgets (like images), wrap in WidgetSpan
+      return WidgetSpan(child: widget);
+    }).toList();
+
+    return RichText(
+      text: TextSpan(
+        style: baseStyle,
+        children: spans,
+      ),
+    );
+  }
+
+  /// Adds spacing between block elements
+  List<Widget> _addSpacing(List<Widget> widgets) {
+    if (widgets.length <= 1) {
+      return widgets;
+    }
+
+    final spacing = styleSheet.blockSpacing ?? 16.0;
+    final result = <Widget>[];
+
+    for (var i = 0; i < widgets.length; i++) {
+      result.add(widgets[i]);
+
+      // Add spacing between blocks (but not after the last one)
+      if (i < widgets.length - 1) {
+        result.add(SizedBox(height: spacing));
+      }
+    }
+
+    return result;
+  }
+
+  /// Registers a custom builder
+  void registerBuilder(String nodeType, MarkdownWidgetBuilder builder) {
+    _builderRegistry.register(nodeType, builder);
+  }
+
+  /// Unregisters a builder
+  void unregisterBuilder(String nodeType) {
+    _builderRegistry.unregister(nodeType);
+  }
+}

--- a/lib/src/renderer/widget_builder.dart
+++ b/lib/src/renderer/widget_builder.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/widgets.dart';
+
+import '../config/style_sheet.dart';
+import '../parser/ast/markdown_node.dart';
+
+/// Base class for building widgets from Markdown nodes
+///
+/// Each type of Markdown element (header, paragraph, list, etc.)
+/// has its own builder that extends this class.
+abstract class MarkdownWidgetBuilder {
+  /// Creates a new widget builder
+  const MarkdownWidgetBuilder();
+
+  /// Builds a widget from a Markdown node
+  ///
+  /// [node] - The Markdown node to render
+  /// [styleSheet] - The style sheet to apply
+  /// [context] - Additional rendering context
+  Widget build(
+    MarkdownNode node,
+    MarkdownStyleSheet styleSheet,
+    MarkdownRenderContext context,
+  );
+
+  /// Checks if this builder can handle the given node type
+  bool canBuild(MarkdownNode node);
+}
+
+/// Context passed to builders during rendering
+///
+/// Contains information needed during the rendering process
+class MarkdownRenderContext {
+  /// Creates a new render context
+  const MarkdownRenderContext({
+    this.onTapLink,
+    this.imageBuilder,
+    this.codeBuilder,
+    this.listLevel = 0,
+  });
+
+  /// Callback for link taps
+  final void Function(String url)? onTapLink;
+
+  /// Custom image widget builder
+  final Widget Function(String url, String? alt, String? title)? imageBuilder;
+
+  /// Custom code block widget builder
+  final Widget Function(String code, String? language)? codeBuilder;
+
+  /// Current list nesting level (for indentation)
+  final int listLevel;
+
+  /// Creates a copy with updated fields
+  MarkdownRenderContext copyWith({
+    void Function(String url)? onTapLink,
+    Widget Function(String url, String? alt, String? title)? imageBuilder,
+    Widget Function(String code, String? language)? codeBuilder,
+    int? listLevel,
+  }) {
+    return MarkdownRenderContext(
+      onTapLink: onTapLink ?? this.onTapLink,
+      imageBuilder: imageBuilder ?? this.imageBuilder,
+      codeBuilder: codeBuilder ?? this.codeBuilder,
+      listLevel: listLevel ?? this.listLevel,
+    );
+  }
+}
+
+/// Registry for Markdown widget builders
+class BuilderRegistry {
+  /// Creates a new builder registry
+  BuilderRegistry() : _builders = {};
+
+  /// Creates a registry with default builders
+  factory BuilderRegistry.defaults() {
+    final registry = BuilderRegistry();
+    // Default builders will be registered here
+    return registry;
+  }
+
+  final Map<String, MarkdownWidgetBuilder> _builders;
+
+  /// Registers a builder for a specific node type
+  void register(String nodeType, MarkdownWidgetBuilder builder) {
+    _builders[nodeType] = builder;
+  }
+
+  /// Gets the builder for a node type
+  MarkdownWidgetBuilder? getBuilder(String nodeType) {
+    return _builders[nodeType];
+  }
+
+  /// Finds a builder that can handle the given node
+  MarkdownWidgetBuilder? findBuilder(MarkdownNode node) {
+    // First try exact type match
+    final exactBuilder = _builders[node.type];
+    if (exactBuilder != null && exactBuilder.canBuild(node)) {
+      return exactBuilder;
+    }
+
+    // Then try all builders
+    for (final builder in _builders.values) {
+      if (builder.canBuild(node)) {
+        return builder;
+      }
+    }
+
+    return null;
+  }
+
+  /// Checks if a builder exists for a node type
+  bool hasBuilder(String nodeType) {
+    return _builders.containsKey(nodeType);
+  }
+
+  /// Removes a builder
+  void unregister(String nodeType) {
+    _builders.remove(nodeType);
+  }
+
+  /// Clears all builders
+  void clear() {
+    _builders.clear();
+  }
+}

--- a/lib/widgets/smooth_markdown.dart
+++ b/lib/widgets/smooth_markdown.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/widgets.dart';
+
+import '../src/config/markdown_config.dart';
+import '../src/config/style_sheet.dart';
+import '../src/parser/markdown_parser.dart';
+import '../src/renderer/markdown_renderer.dart';
+import '../src/renderer/widget_builder.dart';
+
+/// A widget that renders Markdown content
+///
+/// This widget parses and renders Markdown text using the provided
+/// configuration and style sheet.
+///
+/// Example:
+/// ```dart
+/// SmoothMarkdown(
+///   data: '# Hello **World**',
+///   styleSheet: MarkdownStyleSheet.light(),
+///   onTapLink: (url) => print('Tapped: $url'),
+/// )
+/// ```
+class SmoothMarkdown extends StatelessWidget {
+  /// Creates a new SmoothMarkdown widget
+  const SmoothMarkdown({
+    required this.data,
+    super.key,
+    this.styleSheet,
+    this.config,
+    this.onTapLink,
+    this.imageBuilder,
+    this.codeBuilder,
+  });
+
+  /// The Markdown text to render
+  final String data;
+
+  /// The style sheet to use for rendering
+  ///
+  /// If not provided, defaults to [MarkdownStyleSheet.light()]
+  final MarkdownStyleSheet? styleSheet;
+
+  /// Configuration for Markdown parsing
+  final MarkdownConfig? config;
+
+  /// Callback when a link is tapped
+  final void Function(String url)? onTapLink;
+
+  /// Custom image widget builder
+  final Widget Function(String url, String? alt, String? title)? imageBuilder;
+
+  /// Custom code block widget builder
+  final Widget Function(String code, String? language)? codeBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    // Parse markdown
+    final parser = MarkdownParser();
+    final nodes = parser.parse(data);
+
+    // Render nodes
+    final renderer = MarkdownRenderer(
+      styleSheet: styleSheet ?? MarkdownStyleSheet.light(),
+    );
+
+    final renderContext = MarkdownRenderContext(
+      onTapLink: onTapLink,
+      imageBuilder: imageBuilder,
+      codeBuilder: codeBuilder,
+    );
+
+    return renderer.render(nodes, context: renderContext);
+  }
+}

--- a/test/renderer/smooth_markdown_test.dart
+++ b/test/renderer/smooth_markdown_test.dart
@@ -1,0 +1,314 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_smooth_markdown/flutter_smooth_markdown.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('SmoothMarkdown Widget Tests', () {
+    testWidgets('should render simple text', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SmoothMarkdown(
+            data: 'Hello World',
+          ),
+        ),
+      );
+
+      expect(find.text('Hello World'), findsOneWidget);
+    });
+
+    testWidgets('should render header', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SmoothMarkdown(
+            data: '# Header 1',
+          ),
+        ),
+      );
+
+      expect(find.text('Header 1'), findsOneWidget);
+    });
+
+    testWidgets('should render bold text', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SmoothMarkdown(
+            data: '**Bold text**',
+          ),
+        ),
+      );
+
+      expect(find.text('Bold text'), findsOneWidget);
+    });
+
+    testWidgets('should render italic text', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SmoothMarkdown(
+            data: '*Italic text*',
+          ),
+        ),
+      );
+
+      expect(find.text('Italic text'), findsOneWidget);
+    });
+
+    testWidgets('should render inline code', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SmoothMarkdown(
+            data: 'Code: `var x = 1;`',
+          ),
+        ),
+      );
+
+      expect(find.text('Code: '), findsOneWidget);
+      expect(find.text('var x = 1;'), findsOneWidget);
+    });
+
+    testWidgets('should render code block', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SmoothMarkdown(
+            data: '''
+```dart
+void main() {
+  print('Hello');
+}
+```
+''',
+          ),
+        ),
+      );
+
+      expect(find.textContaining('void main()'), findsOneWidget);
+    });
+
+    testWidgets('should render list', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SmoothMarkdown(
+            data: '''
+- Item 1
+- Item 2
+- Item 3
+''',
+          ),
+        ),
+      );
+
+      expect(find.text('Item 1'), findsOneWidget);
+      expect(find.text('Item 2'), findsOneWidget);
+      expect(find.text('Item 3'), findsOneWidget);
+      expect(find.text('• '), findsNWidgets(3));
+    });
+
+    testWidgets('should render ordered list', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SmoothMarkdown(
+            data: '''
+1. First
+2. Second
+3. Third
+''',
+          ),
+        ),
+      );
+
+      expect(find.text('First'), findsOneWidget);
+      expect(find.text('Second'), findsOneWidget);
+      expect(find.text('Third'), findsOneWidget);
+      expect(find.text('1. '), findsOneWidget);
+      expect(find.text('2. '), findsOneWidget);
+      expect(find.text('3. '), findsOneWidget);
+    });
+
+    testWidgets('should render task list', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SmoothMarkdown(
+            data: '''
+- [x] Completed task
+- [ ] Pending task
+''',
+          ),
+        ),
+      );
+
+      expect(find.text('Completed task'), findsOneWidget);
+      expect(find.text('Pending task'), findsOneWidget);
+      expect(find.byIcon(Icons.check_box), findsOneWidget);
+      expect(find.byIcon(Icons.check_box_outline_blank), findsOneWidget);
+    });
+
+    testWidgets('should render blockquote', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SmoothMarkdown(
+            data: '> This is a quote',
+          ),
+        ),
+      );
+
+      expect(find.text('This is a quote'), findsOneWidget);
+    });
+
+    testWidgets('should render horizontal rule', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SmoothMarkdown(
+            data: '''
+Text above
+
+---
+
+Text below
+''',
+          ),
+        ),
+      );
+
+      expect(find.text('Text above'), findsOneWidget);
+      expect(find.text('Text below'), findsOneWidget);
+    });
+
+    testWidgets('should render link', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SmoothMarkdown(
+            data: '[Click here](https://example.com)',
+          ),
+        ),
+      );
+
+      expect(find.text('Click here'), findsOneWidget);
+    });
+
+    testWidgets('should call onTapLink callback', (tester) async {
+      String? tappedUrl;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SmoothMarkdown(
+            data: '[Link](https://example.com)',
+            onTapLink: (url) {
+              tappedUrl = url;
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Link'));
+      expect(tappedUrl, 'https://example.com');
+    });
+
+    testWidgets('should use custom style sheet', (tester) async {
+      final customStyleSheet = MarkdownStyleSheet(
+        h1Style: const TextStyle(fontSize: 48),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SmoothMarkdown(
+            data: '# Big Header',
+            styleSheet: customStyleSheet,
+          ),
+        ),
+      );
+
+      expect(find.text('Big Header'), findsOneWidget);
+      final textWidget = tester.widget<Text>(find.text('Big Header'));
+      expect(textWidget.style?.fontSize, 48);
+    });
+
+    testWidgets('should use custom code builder', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SmoothMarkdown(
+            data: '```dart\ncode\n```',
+            codeBuilder: (code, language) {
+              return Text('Custom: $code ($language)');
+            },
+          ),
+        ),
+      );
+
+      expect(find.textContaining('Custom: code'), findsOneWidget);
+    });
+
+    testWidgets('should use custom image builder', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SmoothMarkdown(
+            data: '![Alt](image.png)',
+            imageBuilder: (url, alt, title) {
+              return Text('Image: $url');
+            },
+          ),
+        ),
+      );
+
+      expect(find.text('Image: image.png'), findsOneWidget);
+    });
+
+    testWidgets('should render complex markdown', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SmoothMarkdown(
+            data: '''
+# Title
+
+This is a paragraph with **bold** and *italic* text.
+
+## List
+
+- Item 1
+- Item 2
+
+```dart
+void main() {
+  print('Hello');
+}
+```
+
+> Quote
+''',
+          ),
+        ),
+      );
+
+      expect(find.text('Title'), findsOneWidget);
+      expect(find.text('bold'), findsOneWidget);
+      expect(find.text('italic'), findsOneWidget);
+      expect(find.text('List'), findsOneWidget);
+      expect(find.text('Item 1'), findsOneWidget);
+      expect(find.text('Quote'), findsOneWidget);
+    });
+
+    testWidgets('should handle empty markdown', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SmoothMarkdown(
+            data: '',
+          ),
+        ),
+      );
+
+      // Should not throw any errors
+      expect(find.byType(SmoothMarkdown), findsOneWidget);
+    });
+
+    testWidgets('should handle whitespace-only markdown', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SmoothMarkdown(
+            data: '   \n\n   ',
+          ),
+        ),
+      );
+
+      // Should not throw any errors
+      expect(find.byType(SmoothMarkdown), findsOneWidget);
+    });
+  });
+}

--- a/test/renderer/widget_builder_test.dart
+++ b/test/renderer/widget_builder_test.dart
@@ -1,0 +1,446 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_smooth_markdown/src/config/style_sheet.dart';
+import 'package:flutter_smooth_markdown/src/parser/ast/markdown_node.dart';
+import 'package:flutter_smooth_markdown/src/renderer/builders/blockquote_builder.dart';
+import 'package:flutter_smooth_markdown/src/renderer/builders/code_block_builder.dart';
+import 'package:flutter_smooth_markdown/src/renderer/builders/header_builder.dart';
+import 'package:flutter_smooth_markdown/src/renderer/builders/horizontal_rule_builder.dart';
+import 'package:flutter_smooth_markdown/src/renderer/builders/image_builder.dart';
+import 'package:flutter_smooth_markdown/src/renderer/builders/inline_code_builder.dart';
+import 'package:flutter_smooth_markdown/src/renderer/builders/link_builder.dart';
+import 'package:flutter_smooth_markdown/src/renderer/builders/list_builder.dart';
+import 'package:flutter_smooth_markdown/src/renderer/builders/paragraph_builder.dart';
+import 'package:flutter_smooth_markdown/src/renderer/builders/text_builder.dart';
+import 'package:flutter_smooth_markdown/src/renderer/builders/text_style_builder.dart';
+import 'package:flutter_smooth_markdown/src/renderer/widget_builder.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Widget Builder Tests', () {
+    late MarkdownStyleSheet styleSheet;
+    late MarkdownRenderContext context;
+
+    setUp(() {
+      styleSheet = MarkdownStyleSheet.light();
+      context = MarkdownRenderContext();
+    });
+
+    group('TextBuilder', () {
+      test('should accept TextNode', () {
+        const builder = TextBuilder();
+        const node = TextNode('test');
+        expect(builder.canBuild(node), true);
+      });
+
+      test('should reject other nodes', () {
+        const builder = TextBuilder();
+        const node = HeaderNode(level: 1, content: 'Test');
+        expect(builder.canBuild(node), false);
+      });
+
+      testWidgets('should build text widget', (tester) async {
+        const builder = TextBuilder();
+        const node = TextNode('Hello World');
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: builder.build(node, styleSheet, context),
+          ),
+        );
+
+        expect(find.text('Hello World'), findsOneWidget);
+      });
+    });
+
+    group('HeaderBuilder', () {
+      test('should accept HeaderNode', () {
+        const builder = HeaderBuilder();
+        const node = HeaderNode(level: 1, content: 'Test');
+        expect(builder.canBuild(node), true);
+      });
+
+      testWidgets('should build header widget', (tester) async {
+        const builder = HeaderBuilder();
+        const node = HeaderNode(level: 1, content: 'Test Header');
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: builder.build(node, styleSheet, context),
+          ),
+        );
+
+        expect(find.text('Test Header'), findsOneWidget);
+      });
+    });
+
+    group('ParagraphBuilder', () {
+      test('should accept ParagraphNode', () {
+        const builder = ParagraphBuilder();
+        const node = ParagraphNode(<MarkdownNode>[]);
+        expect(builder.canBuild(node), true);
+      });
+
+      testWidgets('should build paragraph widget', (tester) async {
+        const builder = ParagraphBuilder();
+        const node = ParagraphNode(<MarkdownNode>[
+          TextNode('Test paragraph'),
+        ]);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: builder.build(node, styleSheet, context),
+          ),
+        );
+
+        expect(find.text('Test paragraph'), findsOneWidget);
+      });
+    });
+
+    group('BoldBuilder', () {
+      test('should accept BoldNode', () {
+        const builder = BoldBuilder();
+        const node = BoldNode(<MarkdownNode>[]);
+        expect(builder.canBuild(node), true);
+      });
+
+      testWidgets('should build bold widget', (tester) async {
+        const builder = BoldBuilder();
+        const node = BoldNode(<MarkdownNode>[
+          TextNode('Bold text'),
+        ]);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: builder.build(node, styleSheet, context),
+          ),
+        );
+
+        expect(find.text('Bold text'), findsOneWidget);
+      });
+    });
+
+    group('ItalicBuilder', () {
+      test('should accept ItalicNode', () {
+        const builder = ItalicBuilder();
+        const node = ItalicNode(<MarkdownNode>[]);
+        expect(builder.canBuild(node), true);
+      });
+
+      testWidgets('should build italic widget', (tester) async {
+        const builder = ItalicBuilder();
+        const node = ItalicNode(<MarkdownNode>[
+          TextNode('Italic text'),
+        ]);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: builder.build(node, styleSheet, context),
+          ),
+        );
+
+        expect(find.text('Italic text'), findsOneWidget);
+      });
+    });
+
+    group('StrikethroughBuilder', () {
+      test('should accept StrikethroughNode', () {
+        const builder = StrikethroughBuilder();
+        const node = StrikethroughNode(<MarkdownNode>[]);
+        expect(builder.canBuild(node), true);
+      });
+
+      testWidgets('should build strikethrough widget', (tester) async {
+        const builder = StrikethroughBuilder();
+        const node = StrikethroughNode(<MarkdownNode>[
+          TextNode('Strikethrough text'),
+        ]);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: builder.build(node, styleSheet, context),
+          ),
+        );
+
+        expect(find.text('Strikethrough text'), findsOneWidget);
+      });
+    });
+
+    group('InlineCodeBuilder', () {
+      test('should accept InlineCodeNode', () {
+        const builder = InlineCodeBuilder();
+        const node = InlineCodeNode('test');
+        expect(builder.canBuild(node), true);
+      });
+
+      testWidgets('should build inline code widget', (tester) async {
+        const builder = InlineCodeBuilder();
+        const node = InlineCodeNode('var x = 1;');
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: builder.build(node, styleSheet, context),
+          ),
+        );
+
+        expect(find.text('var x = 1;'), findsOneWidget);
+      });
+    });
+
+    group('CodeBlockBuilder', () {
+      test('should accept CodeBlockNode', () {
+        const builder = CodeBlockBuilder();
+        const node = CodeBlockNode(code: 'test');
+        expect(builder.canBuild(node), true);
+      });
+
+      testWidgets('should build code block widget', (tester) async {
+        const builder = CodeBlockBuilder();
+        const node = CodeBlockNode(code: 'print("Hello");', language: 'dart');
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: builder.build(node, styleSheet, context),
+          ),
+        );
+
+        expect(find.text('print("Hello");'), findsOneWidget);
+      });
+
+      testWidgets('should use custom code builder', (tester) async {
+        const builder = CodeBlockBuilder();
+        const node = CodeBlockNode(code: 'test code', language: 'js');
+        final customContext = MarkdownRenderContext(
+          codeBuilder: (code, language) => Text('Custom: $code'),
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: builder.build(node, styleSheet, customContext),
+          ),
+        );
+
+        expect(find.text('Custom: test code'), findsOneWidget);
+      });
+    });
+
+    group('BlockquoteBuilder', () {
+      test('should accept BlockquoteNode', () {
+        const builder = BlockquoteBuilder();
+        const node = BlockquoteNode(<MarkdownNode>[]);
+        expect(builder.canBuild(node), true);
+      });
+
+      testWidgets('should build blockquote widget', (tester) async {
+        const builder = BlockquoteBuilder();
+        const node = BlockquoteNode(<MarkdownNode>[
+          ParagraphNode(<MarkdownNode>[TextNode('Quote text')]),
+        ]);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: builder.build(node, styleSheet, context),
+          ),
+        );
+
+        expect(find.text('Quote text'), findsOneWidget);
+      });
+    });
+
+    group('ListBuilder', () {
+      test('should accept ListNode', () {
+        const builder = ListBuilder();
+        const node = ListNode(items: <ListItemNode>[]);
+        expect(builder.canBuild(node), true);
+      });
+
+      testWidgets('should build unordered list', (tester) async {
+        const builder = ListBuilder();
+        const node = ListNode(items: <ListItemNode>[
+          ListItemNode(children: <MarkdownNode>[TextNode('Item 1')]),
+          ListItemNode(children: <MarkdownNode>[TextNode('Item 2')]),
+        ]);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: builder.build(node, styleSheet, context),
+          ),
+        );
+
+        expect(find.text('Item 1'), findsOneWidget);
+        expect(find.text('Item 2'), findsOneWidget);
+        expect(find.text('• '), findsNWidgets(2));
+      });
+
+      testWidgets('should build ordered list', (tester) async {
+        const builder = ListBuilder();
+        const node = ListNode(
+          ordered: true,
+          startIndex: 1,
+          items: <ListItemNode>[
+            ListItemNode(children: <MarkdownNode>[TextNode('First')]),
+            ListItemNode(children: <MarkdownNode>[TextNode('Second')]),
+          ],
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: builder.build(node, styleSheet, context),
+          ),
+        );
+
+        expect(find.text('First'), findsOneWidget);
+        expect(find.text('Second'), findsOneWidget);
+        expect(find.text('1. '), findsOneWidget);
+        expect(find.text('2. '), findsOneWidget);
+      });
+
+      testWidgets('should build task list', (tester) async {
+        const builder = ListBuilder();
+        const node = ListNode(items: <ListItemNode>[
+          ListItemNode(children: <MarkdownNode>[TextNode('Task 1')], checked: true),
+          ListItemNode(children: <MarkdownNode>[TextNode('Task 2')], checked: false),
+        ]);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: builder.build(node, styleSheet, context),
+          ),
+        );
+
+        expect(find.text('Task 1'), findsOneWidget);
+        expect(find.text('Task 2'), findsOneWidget);
+        expect(find.byIcon(Icons.check_box), findsOneWidget);
+        expect(find.byIcon(Icons.check_box_outline_blank), findsOneWidget);
+      });
+    });
+
+    group('HorizontalRuleBuilder', () {
+      test('should accept HorizontalRuleNode', () {
+        const builder = HorizontalRuleBuilder();
+        const node = HorizontalRuleNode();
+        expect(builder.canBuild(node), true);
+      });
+
+      testWidgets('should build horizontal rule widget', (tester) async {
+        const builder = HorizontalRuleBuilder();
+        const node = HorizontalRuleNode();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: builder.build(node, styleSheet, context),
+          ),
+        );
+
+        expect(find.byType(Container), findsOneWidget);
+      });
+    });
+
+    group('LinkBuilder', () {
+      test('should accept LinkNode', () {
+        const builder = LinkBuilder();
+        const node = LinkNode(url: 'https://example.com', children: <MarkdownNode>[]);
+        expect(builder.canBuild(node), true);
+      });
+
+      testWidgets('should build link widget', (tester) async {
+        const builder = LinkBuilder();
+        const node = LinkNode(
+          url: 'https://example.com',
+          children: <MarkdownNode>[TextNode('Click here')],
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: builder.build(node, styleSheet, context),
+          ),
+        );
+
+        expect(find.text('Click here'), findsOneWidget);
+      });
+
+      testWidgets('should call onTapLink callback', (tester) async {
+        const builder = LinkBuilder();
+        const node = LinkNode(
+          url: 'https://example.com',
+          children: <MarkdownNode>[TextNode('Link')],
+        );
+
+        String? tappedUrl;
+        final callbackContext = MarkdownRenderContext(
+          onTapLink: (url) {
+            tappedUrl = url;
+          },
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: builder.build(node, styleSheet, callbackContext),
+          ),
+        );
+
+        await tester.tap(find.text('Link'));
+        expect(tappedUrl, 'https://example.com');
+      });
+    });
+
+    group('ImageBuilder', () {
+      test('should accept ImageNode', () {
+        const builder = ImageBuilder();
+        const node = ImageNode(url: 'test.png', alt: '');
+        expect(builder.canBuild(node), true);
+      });
+
+      testWidgets('should use custom image builder', (tester) async {
+        const builder = ImageBuilder();
+        const node = ImageNode(url: 'test.png', alt: 'Alt text');
+        final customContext = MarkdownRenderContext(
+          imageBuilder: (url, alt, title) => Text('Image: $url'),
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: builder.build(node, styleSheet, customContext),
+          ),
+        );
+
+        expect(find.text('Image: test.png'), findsOneWidget);
+      });
+    });
+
+    group('BuilderRegistry', () {
+      test('should register and retrieve builders', () {
+        final registry = BuilderRegistry();
+        const builder = TextBuilder();
+
+        registry.register('text', builder);
+        expect(registry.getBuilder('text'), builder);
+      });
+
+      test('should return null for unregistered builders', () {
+        final registry = BuilderRegistry();
+        expect(registry.getBuilder('unknown'), isNull);
+      });
+
+      test('should find builder for node type', () {
+        final registry = BuilderRegistry();
+        const textBuilder = TextBuilder();
+        const headerBuilder = HeaderBuilder();
+
+        registry.register('text', textBuilder);
+        registry.register('header', headerBuilder);
+
+        const textNode = TextNode('test');
+        expect(registry.findBuilder(textNode), textBuilder);
+
+        const headerNode = HeaderNode(level: 1, content: 'Test');
+        expect(registry.findBuilder(headerNode), headerBuilder);
+      });
+
+      test('should return null when no builder found', () {
+        final registry = BuilderRegistry();
+        const node = TextNode('test');
+        expect(registry.findBuilder(node), isNull);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Implements core Markdown rendering for Flutter, including widget builders for blockquotes, code blocks, headers, horizontal rules, images, inline code, links, lists, paragraphs, text, and text styles. Adds the main MarkdownRenderer, widget builder registry, and the SmoothMarkdown widget. Updates exports and removes placeholder typedefs. Includes comprehensive widget and builder tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Markdown rendering widget now supports headers, code blocks, lists, blockquotes, horizontal rules, links, and text styling (bold, italic, strikethrough).
  * Customizable styling, code block rendering, and image rendering through configuration options.
  * Link tap interaction callbacks for user engagement.

* **Tests**
  * Added comprehensive widget tests for markdown rendering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->