### PR TITLE
Improve editor performance telemetry and composing stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- ✨ **Editor performance telemetry** - Added `onPerformanceSnapshot` for host apps to observe source size, block/segment counts, segment cache hits, retained segment keys, editor mode, IME composing state, search matches, and suggestion visibility.
+
+### Fixed
+- 🐛 **Editor composing stability** - Deferred semantic document reparsing while an IME composing range is active so formatted editing does not disrupt in-progress input.
+- ⚡ **Formatted editor rebuilds** - Cached formatted block segmentation, pruned stale formatted segment keys, and avoided redundant search state rebuilds.
+
 ## [0.8.0] - 2026-07-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-07-07
+
 ### Added
 - ✨ **Editor performance telemetry** - Added `onPerformanceSnapshot` for host apps to observe source size, block/segment counts, segment cache hits, retained segment keys, editor mode, IME composing state, search matches, and suggestion visibility.
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,13 @@ colors, active button states, search/suggestion panels, selection/drop
 highlights, block chrome, table grid/header/selection colors, source and preview
 decorations, source text style, radii, and content padding.
 
+Large-document integrations can observe lightweight editor telemetry with
+`onPerformanceSnapshot`. The snapshot reports source length, semantic block
+count, formatted segment count, formatted segment cache hits, retained formatted
+segment keys, mode, IME composing state, search match count, and visible
+suggestion panels. This is intended for host-side logging, perf dashboards, or
+debug overlays without reaching into private editor state.
+
 Custom block integrations can pair parser plugins with editor builders. Provide
 `customBlockBuilder` to render unsupported/custom blocks in formatted mode and
 `customBlockEditorBuilder` to supply an editor that calls `replaceMarkdown()`,

--- a/lib/src/editor/markdown_editor_controller.dart
+++ b/lib/src/editor/markdown_editor_controller.dart
@@ -832,10 +832,15 @@ class MarkdownEditorController extends ChangeNotifier {
     if (_syncingSourceFromDocument) return;
 
     final source = textController.text;
-    if (!_hasActiveComposing(textController.value)) {
+    final hasActiveComposing = _hasActiveComposing(textController.value);
+    if (!hasActiveComposing) {
       _recordSourceHistory(textController.value, coalesceEventLoop: true);
     }
     if (source != _lastParsedText) {
+      if (hasActiveComposing) {
+        notifyListeners();
+        return;
+      }
       _lastParsedText = source;
       _syncingDocumentFromSource = true;
       documentEditor.replaceDocument(

--- a/lib/widgets/smooth_markdown_editor.dart
+++ b/lib/widgets/smooth_markdown_editor.dart
@@ -153,6 +153,62 @@ typedef MarkdownEditorImagePickEventCallback = void Function(
   MarkdownEditorImagePickEvent event,
 );
 
+/// Lightweight editor performance snapshot for host telemetry.
+class MarkdownEditorPerformanceSnapshot {
+  /// Creates editor performance telemetry.
+  const MarkdownEditorPerformanceSnapshot({
+    required this.sourceLength,
+    required this.blockCount,
+    required this.formattedSegmentCount,
+    required this.formattedSegmentCacheHit,
+    required this.retainedFormattedSegmentKeyCount,
+    required this.mode,
+    required this.isComposing,
+    required this.searchMatchCount,
+    required this.slashSuggestionsVisible,
+    required this.wikilinkSuggestionsVisible,
+    required this.timestamp,
+  });
+
+  /// Current Markdown source length.
+  final int sourceLength;
+
+  /// Current semantic document block count.
+  final int blockCount;
+
+  /// Current formatted block segment count.
+  final int formattedSegmentCount;
+
+  /// Whether the latest formatted segment lookup reused cached segments.
+  final bool formattedSegmentCacheHit;
+
+  /// Number of retained global keys for formatted block anchoring.
+  final int retainedFormattedSegmentKeyCount;
+
+  /// Current editor display mode.
+  final MarkdownEditorMode mode;
+
+  /// Whether the source controller is inside an active IME composition range.
+  final bool isComposing;
+
+  /// Current find match count.
+  final int searchMatchCount;
+
+  /// Whether slash command suggestions are currently visible.
+  final bool slashSuggestionsVisible;
+
+  /// Whether wikilink suggestions are currently visible.
+  final bool wikilinkSuggestionsVisible;
+
+  /// Snapshot creation time.
+  final DateTime timestamp;
+}
+
+/// Called after editor state changes with lightweight performance telemetry.
+typedef MarkdownEditorPerformanceCallback = void Function(
+  MarkdownEditorPerformanceSnapshot snapshot,
+);
+
 /// Host callback for editor keyboard shortcuts.
 typedef MarkdownEditorShortcutCallback = KeyEventResult Function(
   KeyEvent event,
@@ -726,6 +782,7 @@ class SmoothMarkdownEditor extends StatefulWidget {
     this.onCommand,
     this.onSelectionChanged,
     this.onFocusChanged,
+    this.onPerformanceSnapshot,
     this.enableWikilinks = true,
     this.wikilinkSuggestions = const [],
     this.onTapWikilink,
@@ -867,6 +924,9 @@ class SmoothMarkdownEditor extends StatefulWidget {
   /// Called when the source editor focus changes.
   final ValueChanged<bool>? onFocusChanged;
 
+  /// Called after editor state changes with lightweight performance telemetry.
+  final MarkdownEditorPerformanceCallback? onPerformanceSnapshot;
+
   /// Whether preview parses and renders `[[wikilinks]]`.
   final bool enableWikilinks;
 
@@ -976,6 +1036,11 @@ class _SmoothMarkdownEditorState extends State<SmoothMarkdownEditor> {
   final ScrollController _sourceScrollController = ScrollController();
   final GlobalKey _formattedViewportKey = GlobalKey();
   final Map<String, GlobalKey> _formattedSegmentKeys = <String, GlobalKey>{};
+  String? _cachedBlockSegmentsText;
+  MarkdownDocument? _cachedBlockSegmentsDocument;
+  List<_MarkdownBlockSegment>? _cachedBlockSegments;
+  bool _lastFormattedSegmentCacheHit = false;
+  bool _performanceSnapshotScheduled = false;
 
   final TextEditingController _searchController = TextEditingController();
   final _FormattedBlockTextController _formattedBlockController =
@@ -1108,10 +1173,11 @@ class _SmoothMarkdownEditorState extends State<SmoothMarkdownEditor> {
 
   void _handleControllerChanged() {
     _refreshInlineSuggestions();
-    _refreshSearchMatches();
+    _refreshSearchMatches(notify: false);
     _clearActiveDocumentSelectionIfInvalid();
     _reportSelectionChanged();
     widget.onChanged?.call(_controller.text);
+    _schedulePerformanceSnapshot();
     if (mounted) {
       setState(() {});
     }
@@ -1119,6 +1185,37 @@ class _SmoothMarkdownEditorState extends State<SmoothMarkdownEditor> {
 
   void _handleFocusChanged() {
     widget.onFocusChanged?.call(_focusNode.hasFocus);
+  }
+
+  void _schedulePerformanceSnapshot({bool? formattedSegmentCacheHit}) {
+    if (formattedSegmentCacheHit != null) {
+      _lastFormattedSegmentCacheHit = formattedSegmentCacheHit;
+    }
+    if (widget.onPerformanceSnapshot == null || _performanceSnapshotScheduled) {
+      return;
+    }
+
+    _performanceSnapshotScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _performanceSnapshotScheduled = false;
+      widget.onPerformanceSnapshot?.call(
+        MarkdownEditorPerformanceSnapshot(
+          sourceLength: _controller.text.length,
+          blockCount: _controller.document.blocks.length,
+          formattedSegmentCount: _cachedBlockSegments?.length ??
+              _controller.document.blocks.length,
+          formattedSegmentCacheHit: _lastFormattedSegmentCacheHit,
+          retainedFormattedSegmentKeyCount: _formattedSegmentKeys.length,
+          mode: _mode,
+          isComposing: _hasActiveComposing(_controller.textController.value),
+          searchMatchCount: _searchMatches.length,
+          slashSuggestionsVisible: _slashMatch != null,
+          wikilinkSuggestionsVisible: _wikilinkMatch != null,
+          timestamp: DateTime.now(),
+        ),
+      );
+    });
   }
 
   void _reportSelectionChanged() {
@@ -1990,6 +2087,7 @@ class _SmoothMarkdownEditorState extends State<SmoothMarkdownEditor> {
     final theme = Theme.of(context);
     final editorTheme = _effectiveEditorTheme(context);
     final segments = _documentBlockSegments();
+    _pruneFormattedSegmentKeys(segments);
     final blockSpacing = _effectiveStyleSheet(context).blockSpacing ?? 16;
     final contentPadding =
         editorTheme.contentPadding ?? const EdgeInsets.all(16);
@@ -8374,10 +8472,26 @@ class _SmoothMarkdownEditorState extends State<SmoothMarkdownEditor> {
     _formattedScrollController.jumpTo(clampedTarget.toDouble());
   }
 
+  void _pruneFormattedSegmentKeys(List<_MarkdownBlockSegment> segments) {
+    if (_formattedSegmentKeys.isEmpty) return;
+    if (segments.isEmpty) {
+      _formattedSegmentKeys.clear();
+      return;
+    }
+
+    final retainedIds = <String>{
+      for (final segment in segments) _formattedSegmentKeyId(segment),
+    };
+    _formattedSegmentKeys.removeWhere((id, _) => !retainedIds.contains(id));
+  }
+
   GlobalKey _formattedSegmentGlobalKey(_MarkdownBlockSegment segment) {
-    final id =
-        '${segment.range.start}:${segment.range.end}:${segment.block?.id ?? ''}';
+    final id = _formattedSegmentKeyId(segment);
     return _formattedSegmentKeys.putIfAbsent(id, GlobalKey.new);
+  }
+
+  String _formattedSegmentKeyId(_MarkdownBlockSegment segment) {
+    return '${segment.range.start}:${segment.range.end}:${segment.block?.id ?? ''}';
   }
 
   _FormattedActivationTarget? _formattedActivationTargetForSelection(
@@ -10217,8 +10331,15 @@ class _SmoothMarkdownEditorState extends State<SmoothMarkdownEditor> {
     _refreshSearchMatches();
   }
 
-  void _refreshSearchMatches() {
+  void _refreshSearchMatches({bool notify = true}) {
     final query = _searchController.text;
+    if (!_searchOpen &&
+        query.isEmpty &&
+        _lastSearchQuery.isEmpty &&
+        _searchMatches.isEmpty) {
+      return;
+    }
+
     final matches = _findSearchMatches(query);
     final queryChanged = query != _lastSearchQuery;
     var nextIndex = _currentSearchMatchIndex;
@@ -10232,7 +10353,12 @@ class _SmoothMarkdownEditorState extends State<SmoothMarkdownEditor> {
       nextIndex = matches.length - 1;
     }
 
-    if (mounted) {
+    final changed = queryChanged ||
+        nextIndex != _currentSearchMatchIndex ||
+        !listEquals(matches, _searchMatches);
+    if (!changed) return;
+
+    if (notify && mounted) {
       setState(() {
         _searchMatches = matches;
         _currentSearchMatchIndex = nextIndex;
@@ -11027,11 +11153,28 @@ class _SmoothMarkdownEditorState extends State<SmoothMarkdownEditor> {
 
   List<_MarkdownBlockSegment> _documentBlockSegments() {
     final text = _controller.text;
-    if (text.trim().isEmpty) return const [];
+    final document = _controller.document;
+    final cached = _cachedBlockSegments;
+    if (_cachedBlockSegmentsText == text &&
+        identical(_cachedBlockSegmentsDocument, document) &&
+        cached != null) {
+      _schedulePerformanceSnapshot(formattedSegmentCacheHit: true);
+      return cached;
+    }
+
+    if (text.trim().isEmpty) {
+      _cacheBlockSegments(text, document, const []);
+      _schedulePerformanceSnapshot(formattedSegmentCacheHit: false);
+      return const [];
+    }
 
     final sourceSegments = _markdownBlockSegments(text);
-    final blocks = _controller.document.blocks;
-    if (blocks.isEmpty) return sourceSegments;
+    final blocks = document.blocks;
+    if (blocks.isEmpty) {
+      _cacheBlockSegments(text, document, sourceSegments);
+      _schedulePerformanceSnapshot(formattedSegmentCacheHit: false);
+      return sourceSegments;
+    }
 
     final segments = <_MarkdownBlockSegment>[];
     var sourceIndex = 0;
@@ -11069,7 +11212,19 @@ class _SmoothMarkdownEditorState extends State<SmoothMarkdownEditor> {
       }
     }
 
+    _cacheBlockSegments(text, document, segments);
+    _schedulePerformanceSnapshot(formattedSegmentCacheHit: false);
     return segments;
+  }
+
+  void _cacheBlockSegments(
+    String text,
+    MarkdownDocument document,
+    List<_MarkdownBlockSegment> segments,
+  ) {
+    _cachedBlockSegmentsText = text;
+    _cachedBlockSegmentsDocument = document;
+    _cachedBlockSegments = segments;
   }
 
   TextRange _sourceRangeForDocumentBlock(

--- a/lib/widgets/smooth_markdown_editor.dart
+++ b/lib/widgets/smooth_markdown_editor.dart
@@ -1200,8 +1200,11 @@ class _SmoothMarkdownEditorState extends State<SmoothMarkdownEditor> {
     if (formattedSegmentCacheHit != null) {
       _lastFormattedSegmentCacheHit = formattedSegmentCacheHit;
     }
-    _pendingSnapshotIsComposing =
+    final nextIsComposing =
         isComposing ?? _hasActiveComposing(_controller.textController.value);
+    if (!_performanceSnapshotScheduled || isComposing != null) {
+      _pendingSnapshotIsComposing = nextIsComposing;
+    }
     if (widget.onPerformanceSnapshot == null || _performanceSnapshotScheduled) {
       return;
     }
@@ -11179,14 +11182,6 @@ class _SmoothMarkdownEditorState extends State<SmoothMarkdownEditor> {
     final text = _controller.text;
     final document = _controller.document;
     final cached = _cachedBlockSegments;
-    if (_hasActiveComposing(_controller.textController.value) &&
-        cached != null) {
-      _schedulePerformanceSnapshot(
-        formattedSegmentCacheHit: true,
-        isComposing: true,
-      );
-      return cached;
-    }
     if (_cachedBlockSegmentsText == text &&
         identical(_cachedBlockSegmentsDocument, document) &&
         cached != null) {

--- a/lib/widgets/smooth_markdown_editor.dart
+++ b/lib/widgets/smooth_markdown_editor.dart
@@ -1041,6 +1041,7 @@ class _SmoothMarkdownEditorState extends State<SmoothMarkdownEditor> {
   List<_MarkdownBlockSegment>? _cachedBlockSegments;
   bool _lastFormattedSegmentCacheHit = false;
   bool _performanceSnapshotScheduled = false;
+  bool _pendingSnapshotIsComposing = false;
 
   final TextEditingController _searchController = TextEditingController();
   final _FormattedBlockTextController _formattedBlockController =
@@ -1172,13 +1173,18 @@ class _SmoothMarkdownEditorState extends State<SmoothMarkdownEditor> {
   }
 
   void _handleControllerChanged() {
-    _refreshInlineSuggestions();
-    _refreshSearchMatches(notify: false);
-    _clearActiveDocumentSelectionIfInvalid();
+    final composing = _hasActiveComposing(_controller.textController.value);
+    if (!composing) {
+      _refreshInlineSuggestions();
+      _refreshSearchMatches(notify: false);
+      _clearActiveDocumentSelectionIfInvalid();
+    }
     _reportSelectionChanged();
-    widget.onChanged?.call(_controller.text);
-    _schedulePerformanceSnapshot();
-    if (mounted) {
+    if (!composing) {
+      widget.onChanged?.call(_controller.text);
+    }
+    _schedulePerformanceSnapshot(isComposing: composing);
+    if (mounted && !composing) {
       setState(() {});
     }
   }
@@ -1187,10 +1193,15 @@ class _SmoothMarkdownEditorState extends State<SmoothMarkdownEditor> {
     widget.onFocusChanged?.call(_focusNode.hasFocus);
   }
 
-  void _schedulePerformanceSnapshot({bool? formattedSegmentCacheHit}) {
+  void _schedulePerformanceSnapshot({
+    bool? formattedSegmentCacheHit,
+    bool? isComposing,
+  }) {
     if (formattedSegmentCacheHit != null) {
       _lastFormattedSegmentCacheHit = formattedSegmentCacheHit;
     }
+    _pendingSnapshotIsComposing =
+        isComposing ?? _hasActiveComposing(_controller.textController.value);
     if (widget.onPerformanceSnapshot == null || _performanceSnapshotScheduled) {
       return;
     }
@@ -1208,7 +1219,7 @@ class _SmoothMarkdownEditorState extends State<SmoothMarkdownEditor> {
           formattedSegmentCacheHit: _lastFormattedSegmentCacheHit,
           retainedFormattedSegmentKeyCount: _formattedSegmentKeys.length,
           mode: _mode,
-          isComposing: _hasActiveComposing(_controller.textController.value),
+          isComposing: _pendingSnapshotIsComposing,
           searchMatchCount: _searchMatches.length,
           slashSuggestionsVisible: _slashMatch != null,
           wikilinkSuggestionsVisible: _wikilinkMatch != null,
@@ -1956,7 +1967,7 @@ class _SmoothMarkdownEditorState extends State<SmoothMarkdownEditor> {
             IconButton(
               tooltip: 'Close find',
               icon: const Icon(Icons.close),
-              onPressed: () => setState(() => _searchOpen = false),
+              onPressed: _closeSearch,
             ),
           ],
         ),
@@ -7775,7 +7786,7 @@ class _SmoothMarkdownEditorState extends State<SmoothMarkdownEditor> {
     final key = event.logicalKey;
     if (key == LogicalKeyboardKey.escape) {
       if (_searchOpen) {
-        setState(() => _searchOpen = false);
+        _closeSearch();
       }
       _focusNode.requestFocus();
       return KeyEventResult.handled;
@@ -10331,12 +10342,25 @@ class _SmoothMarkdownEditorState extends State<SmoothMarkdownEditor> {
     _refreshSearchMatches();
   }
 
+  void _closeSearch() {
+    setState(() {
+      _searchOpen = false;
+      _searchMatches = const [];
+      _currentSearchMatchIndex = 0;
+      _lastSearchQuery = '';
+    });
+  }
+
   void _refreshSearchMatches({bool notify = true}) {
     final query = _searchController.text;
-    if (!_searchOpen &&
-        query.isEmpty &&
-        _lastSearchQuery.isEmpty &&
-        _searchMatches.isEmpty) {
+    if (!_searchOpen) {
+      if (_searchMatches.isNotEmpty ||
+          _lastSearchQuery.isNotEmpty ||
+          _currentSearchMatchIndex != 0) {
+        _searchMatches = const [];
+        _currentSearchMatchIndex = 0;
+        _lastSearchQuery = '';
+      }
       return;
     }
 
@@ -11155,6 +11179,14 @@ class _SmoothMarkdownEditorState extends State<SmoothMarkdownEditor> {
     final text = _controller.text;
     final document = _controller.document;
     final cached = _cachedBlockSegments;
+    if (_hasActiveComposing(_controller.textController.value) &&
+        cached != null) {
+      _schedulePerformanceSnapshot(
+        formattedSegmentCacheHit: true,
+        isComposing: true,
+      );
+      return cached;
+    }
     if (_cachedBlockSegmentsText == text &&
         identical(_cachedBlockSegmentsDocument, document) &&
         cached != null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_smooth_markdown
 description: High-performance Flutter markdown renderer and editor with syntax highlighting, LaTeX math, tables, footnotes, SVG images, and real-time streaming support.
-version: 0.8.0
+version: 0.8.1
 homepage: https://github.com/JackCaow/flutter-smooth-markdown
 repository: https://github.com/JackCaow/flutter-smooth-markdown
 issue_tracker: https://github.com/JackCaow/flutter-smooth-markdown/issues

--- a/test/editor/markdown_editor_public_api_test.dart
+++ b/test/editor/markdown_editor_public_api_test.dart
@@ -104,6 +104,21 @@ void main() {
         toolbarColor: Color(0xFF102030),
       );
       expect(theme.toolbarColor, const Color(0xFF102030));
+
+      final snapshot = editor_api.MarkdownEditorPerformanceSnapshot(
+        sourceLength: 4,
+        blockCount: 1,
+        formattedSegmentCount: 1,
+        formattedSegmentCacheHit: true,
+        retainedFormattedSegmentKeyCount: 1,
+        mode: editor_api.MarkdownEditorMode.formatted,
+        isComposing: false,
+        searchMatchCount: 0,
+        slashSuggestionsVisible: false,
+        wikilinkSuggestionsVisible: false,
+        timestamp: DateTime(2026),
+      );
+      expect(snapshot.formattedSegmentCacheHit, isTrue);
     });
   });
 }

--- a/test/editor/markdown_editor_public_api_test.dart
+++ b/test/editor/markdown_editor_public_api_test.dart
@@ -119,6 +119,10 @@ void main() {
         timestamp: DateTime(2026),
       );
       expect(snapshot.formattedSegmentCacheHit, isTrue);
+      expect(snapshot.sourceLength, 4);
+      expect(snapshot.blockCount, 1);
+      expect(snapshot.mode, editor_api.MarkdownEditorMode.formatted);
+      expect(snapshot.isComposing, isFalse);
     });
   });
 }

--- a/test/widgets/smooth_markdown_editor_test.dart
+++ b/test/widgets/smooth_markdown_editor_test.dart
@@ -1198,6 +1198,20 @@ void main() {
         snapshots.last.retainedFormattedSegmentKeyCount,
         greaterThanOrEqualTo(2),
       );
+
+      await tester.enterText(find.byType(TextField).first, 'Body');
+      await tester.pump();
+      expect(find.text('1/1'), findsOneWidget);
+
+      snapshots.clear();
+      await tester.tap(find.byTooltip('Close find'));
+      await tester.pump();
+      controller.text = '# Title\n\nBody changed';
+      await tester.pump();
+      await tester.pump();
+
+      expect(snapshots, isNotEmpty);
+      expect(snapshots.last.searchMatchCount, 0);
     });
 
     testWidgets('formatted preview defaults to dark theme colors',
@@ -1386,6 +1400,53 @@ void main() {
       await tester.pump();
 
       expect(focusModeChanges, <bool>[true]);
+    });
+
+    testWidgets('defers host updates and reports composing snapshots',
+        (tester) async {
+      final controller = MarkdownEditorController(text: 'Draft');
+      final textChanges = <String>[];
+      final snapshots = <MarkdownEditorPerformanceSnapshot>[];
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        _wrap(
+          SmoothMarkdownEditor(
+            controller: controller,
+            initialMode: MarkdownEditorMode.source,
+            height: 240,
+            onChanged: textChanges.add,
+            onPerformanceSnapshot: snapshots.add,
+          ),
+        ),
+      );
+
+      snapshots.clear();
+      controller.textController.value = const TextEditingValue(
+        text: '# 标题',
+        selection: TextSelection.collapsed(offset: 4),
+        composing: TextRange(start: 2, end: 4),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(textChanges, isEmpty);
+      expect(_singleScratchContentBlock(controller),
+          isA<MarkdownParagraphBlock>());
+      expect(snapshots, isNotEmpty);
+      expect(snapshots.last.isComposing, isTrue);
+
+      controller.textController.value = const TextEditingValue(
+        text: '# 标题',
+        selection: TextSelection.collapsed(offset: 4),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(textChanges, contains('# 标题'));
+      expect(
+          _singleScratchContentBlock(controller), isA<MarkdownHeadingBlock>());
+      expect(snapshots.last.isComposing, isFalse);
     });
 
     testWidgets('formatted pane lazily renders long documents', (tester) async {

--- a/test/widgets/smooth_markdown_editor_test.dart
+++ b/test/widgets/smooth_markdown_editor_test.dart
@@ -441,6 +441,8 @@ void main() {
         const TextRange(start: 2, end: 4),
       );
       expect(controller.canUndo, isFalse);
+      expect(_singleScratchContentBlock(controller),
+          isA<MarkdownParagraphBlock>());
 
       controller.textController.value = const TextEditingValue(
         text: '# 标题',
@@ -1157,6 +1159,45 @@ void main() {
       await tester.pump();
 
       expect(controller.text, '# Edited\n\nBody');
+    });
+
+    testWidgets(
+        'reports performance snapshots and formatted segment cache hits',
+        (tester) async {
+      final controller = MarkdownEditorController(text: '# Title\n\nBody');
+      addTearDown(controller.dispose);
+      final snapshots = <MarkdownEditorPerformanceSnapshot>[];
+
+      await tester.pumpWidget(
+        _wrap(
+          SmoothMarkdownEditor(
+            controller: controller,
+            height: 240,
+            onPerformanceSnapshot: snapshots.add,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(snapshots, isNotEmpty);
+      expect(snapshots.last.sourceLength, controller.text.length);
+      expect(snapshots.last.blockCount, controller.document.blocks.length);
+      expect(snapshots.last.formattedSegmentCount, greaterThanOrEqualTo(2));
+
+      snapshots.clear();
+      await _tapToolbarIcon(tester, Icons.search);
+      await tester.pump();
+      await tester.pump();
+
+      expect(snapshots, isNotEmpty);
+      expect(
+        snapshots.last.formattedSegmentCacheHit,
+        isTrue,
+      );
+      expect(
+        snapshots.last.retainedFormattedSegmentKeyCount,
+        greaterThanOrEqualTo(2),
+      );
     });
 
     testWidgets('formatted preview defaults to dark theme colors',


### PR DESCRIPTION
## Summary
- add host-facing editor performance snapshots for document size, segment cache hits, retained segment keys, mode, composing state, search matches, and suggestion visibility
- defer semantic document reparsing while IME composition is active to avoid disrupting in-progress input
- cache formatted block segmentation, prune stale formatted segment keys, and avoid redundant search rebuilds
- document the telemetry API and add changelog coverage

## Tests
- dart format --set-exit-if-changed lib/src/editor/markdown_editor_controller.dart lib/widgets/smooth_markdown_editor.dart test/editor/markdown_editor_public_api_test.dart test/widgets/smooth_markdown_editor_test.dart
- flutter analyze --no-fatal-infos
- flutter test test/editor/markdown_editor_public_api_test.dart test/widgets/smooth_markdown_editor_test.dart
- flutter test

<!-- chanzi-review-bot:report:start -->
### AI Review Summary

**Changes:**

No summary available yet.

**Stats:**
7 files reviewed
<!-- chanzi-review-bot:report:end -->