### PR TITLE
feat: add safe opt-in HTML rendering  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🐛 **Details inline formatting** - Inline markdown (bold, italic, links) inside `<details>` bodies now renders instead of showing literal `**` markers.
 - 🐛 **Parse cache config isolation** - The shared parse cache now keys on the HTML config so widgets with different `enableHtml` settings never reuse each other's ASTs.
 
+### Improved
+- ⚡ **Plain-text fast path** - Rewrote the inline parser's plain-text scanner (code-unit scan + single substring instead of per-character buffering), cutting typical-document parse time by ~20% for all content, HTML or not.
+- ⚡ **HTML tag pre-filter** - `<` only breaks the text run when followed by a letter or `/`, so prose like `a < b` or `2<3` stays on the fast path; angle-bracket-heavy overhead drops from ~1.4x to ~1.15x.
+- ⚡ **Zero-copy cache keys** - Separate parse caches per HTML config replace the prefixed-key string, removing an O(n) document copy per build for HTML-enabled widgets.
+
 ### Changed
 - ⚠️ **Escape set** - `\<` is now a recognized CommonMark backslash escape (renders a literal `<`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-17
+
+### Added
+- ✨ **HTML tag rendering** - Opt-in whitelist HTML support behind `MarkdownConfig(enableHtml: true)`: inline formatting tags (`b/strong`, `i/em`, `u/ins`, `s/del/strike`, `mark`, `sub`, `sup`, `kbd`, `code`, `br`), links and sized images (`a`, `img` with `width`/`height`), colored text (`font color/size`, `span style` safe subset), and block elements (`div`, `p`, `center`, `blockquote`, `hr`) with `align` attribute support. Unknown tags are stripped keeping their content; unclosed tags auto-close for streaming stability.
+- ✨ **HTML AST nodes** - New `UnderlineNode`, `HighlightNode`, `SubscriptNode`, `SuperscriptNode`, `KbdNode`, `StyledSpanNode`, and `HtmlBlockNode` node types, plus optional `width`/`height` on `ImageNode`.
+- ✨ **HTML theming** - New `underlineStyle`, `highlightStyle`, `kbdStyle`, `subscriptStyle`, and `superscriptStyle` fields on `MarkdownStyleSheet`, populated in the light and dark themes.
+- 🔒 **HTML safety** - Tag whitelist, URL scheme validation for `href`/`src` (rejects `javascript:`, `data:`, etc.), safe style subset (color, background color, font size), bounded tag lexing, and nesting depth limits. HTML stays fully disabled by default.
+- 🧪 **Tests** - Parser, renderer, integration, and streaming coverage for HTML rendering, including parse-cache isolation across configs and dual builder-registry registration.
+- 📝 **HTML demo page** - New example page with an enable/disable toggle covering all supported tags.
+
+### Fixed
+- 🐛 **Details inline formatting** - Inline markdown (bold, italic, links) inside `<details>` bodies now renders instead of showing literal `**` markers.
+- 🐛 **Parse cache config isolation** - The shared parse cache now keys on the HTML config so widgets with different `enableHtml` settings never reuse each other's ASTs.
+
+### Changed
+- ⚠️ **Escape set** - `\<` is now a recognized CommonMark backslash escape (renders a literal `<`).
+
 ## [0.8.1] - 2026-07-07
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Flutter Smooth Markdown** is a high-performance Flutter markdown renderer with syntax highlighting, LaTeX math, tables, footnotes, SVG images, and real-time streaming support. The package provides a custom AST-based parser and extensible widget builder system.
 
-- **Version**: 0.2.0
+- **Version**: 0.9.0
 - **Minimum SDK**: Dart >=3.0.0, Flutter >=3.0.0
 - **Repository**: https://github.com/JackCaow/flutter-smooth-markdown
 
@@ -248,7 +248,7 @@ Key areas for optimization:
 
 ## Project Status
 
-**Completed Features** (as of v0.3.2):
+**Completed Features** (as of v0.9.0):
 - ✅ Complete AST-based parser (block + inline)
 - ✅ Widget builder system with registry
 - ✅ All standard markdown syntax (CommonMark)
@@ -263,6 +263,7 @@ Key areas for optimization:
 - ✅ Comprehensive API documentation
 - ✅ Details/Summary collapsible blocks
 - ✅ Plugin system for custom parsers (MentionPlugin, HashtagPlugin, EmojiPlugin, AdmonitionPlugin)
+- ✅ Whitelist HTML tag rendering (opt-in via `MarkdownConfig.enableHtml`; parser in `lib/src/parser/html/html_utils.dart` + inline/block parsers, nodes in `lib/src/parser/ast/html_nodes.dart`, builders in `html_inline_builder.dart`/`html_block_builder.dart`; see `doc/HTML支持.md`)
 
 **Future Enhancements**:
 - Performance optimization and benchmarking

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A high-performance Flutter markdown renderer with syntax highlighting, LaTeX mat
 | **Editing** | Formatted/source/preview/split editor, formatting toolbar, slash commands, wikilinks, find |
 | **Markdown** | Headers (with inline formatting), lists, tables, code blocks, blockquotes, links, images |
 | **Math & Charts** | LaTeX formulas, Mermaid diagrams (flowcharts, Gantt, Kanban, Timeline, Radar, XY Chart, pie, sequence) |
-| **Extras** | Footnotes, SVG support, collapsible sections, task lists |
+| **Extras** | Footnotes, SVG support, collapsible sections, task lists, whitelisted HTML tags (opt-in) |
 | **Theming** | Light/dark modes, GitHub/VS Code presets, custom themes |
 | **Plugins** | Mentions, hashtags, emojis, AI chat blocks (thinking, artifacts) |
 
@@ -53,7 +53,7 @@ A high-performance Flutter markdown renderer with syntax highlighting, LaTeX mat
 
 ```yaml
 dependencies:
-  flutter_smooth_markdown: ^0.8.0
+  flutter_smooth_markdown: ^0.9.0
 ```
 
 ```bash
@@ -263,6 +263,28 @@ StreamMarkdown(
   styleSheet: MarkdownStyleSheet.dark(),
 )
 ```
+
+### HTML Tags (opt-in)
+
+Render a safe whitelist of HTML tags — inline formatting (`<b>`, `<u>`,
+`<mark>`, `<sub>`, `<sup>`, `<kbd>`, `<br>`, ...), links and sized
+images, colored `<font>`/`<span>` text, and block elements (`<div>`,
+`<p>`, `<center>`, `<blockquote>`, `<hr>`) with `align` support.
+Disabled by default for security; unknown tags are stripped keeping
+their content, and unsafe URL schemes (`javascript:`, `data:`) are
+rejected.
+
+```dart
+SmoothMarkdown(
+  data: 'Press <kbd>Ctrl</kbd>+<kbd>C</kbd>, H<sub>2</sub>O, '
+      '<mark>highlight</mark><br><center>centered</center>',
+  config: const MarkdownConfig(enableHtml: true), // trusted content only
+)
+```
+
+Works with streaming out of the box — unclosed tags auto-close at the
+end of the buffer, so `<b>partial` renders bold mid-stream. See
+`doc/HTML支持.md` for the full tag list and security policy.
 
 ### Enhanced Components
 

--- a/doc/HTML支持.md
+++ b/doc/HTML支持.md
@@ -1,0 +1,92 @@
+# HTML 支持
+
+Flutter Smooth Markdown 支持渲染一个安全白名单内的 HTML 标签。该功能默认**关闭**，需要通过 `MarkdownConfig(enableHtml: true)` 显式开启。
+
+## 快速开始
+
+```dart
+SmoothMarkdown(
+  data: '按 <kbd>Ctrl</kbd> + <kbd>C</kbd> 复制 <mark>高亮文本</mark>',
+  config: const MarkdownConfig(enableHtml: true),
+)
+```
+
+流式渲染（`StreamMarkdown`）与编辑器预览会自动继承该配置。
+
+## 支持的标签
+
+### 内联标签
+
+| 标签 | 效果 |
+|------|------|
+| `<b>` / `<strong>` | **加粗** |
+| `<i>` / `<em>` | *斜体* |
+| `<u>` / `<ins>` | 下划线 |
+| `<s>` / `<del>` / `<strike>` | ~~删除线~~ |
+| `<mark>` | 高亮 |
+| `<sub>` / `<sup>` | 下标 / 上标 |
+| `<kbd>` | 键盘按键样式 |
+| `<code>` | 行内代码（内容原样保留，不递归解析） |
+| `<br>` / `<br/>` | 强制换行 |
+| `<a href="..." title="...">` | 链接（复用 `onTapLink` 回调） |
+| `<img src alt title width height>` | 图片（支持尺寸、网络缓存与 SVG） |
+| `<font color="..." size="1-7">` | 文字颜色 / 传统字号 |
+| `<span style="...">` | 安全样式子集（见下） |
+
+### 块级标签
+
+| 标签 | 效果 |
+|------|------|
+| `<div>` / `<p>` | 块容器，支持 `align` 属性 |
+| `<center>` | 居中块 |
+| `<blockquote>` | 引用块（复用 Markdown 引用样式） |
+| `<hr>` / `<hr/>` | 分隔线（需独占一行） |
+| `<details>` / `<summary>` | 折叠块（始终可用，不受 `enableHtml` 控制） |
+
+块级标签需位于行首才按块解析；出现在段落中间时按内联降级规则处理。块内容会递归解析为 Markdown，因此块内可以使用标题、列表、代码块等语法。
+
+## 样式安全子集
+
+`<span style="...">` 仅识别以下 CSS 属性，其余静默忽略：
+
+- `color`：`#RGB`、`#RRGGBB` 或常见颜色名（`red`、`blue` 等）
+- `background-color`：同上
+- `font-size`：`px`、`pt` 或纯数字（限制在 4–128px）
+
+不支持 8 位 hex 颜色（CSS 与 Flutter 的通道顺序语义冲突）。
+
+## 安全策略
+
+- **标签白名单**：白名单之外的合法标签会被剥离，仅保留其内容（与聊天类渲染器一致）
+- **URL scheme 校验**：`href` / `src` 仅允许 `http`、`https`、`mailto`、`tel` 与相对路径；`javascript:`、`data:`、`file:` 等一律拒绝——不安全链接剥离标签保留文字，不安全图片降级为 alt 文本
+- **词法边界**：单个标签最长 512 字符，嵌套深度上限 16，防止病态输入
+- **代码保护**：行内代码、代码块、数学公式中的 `<` 不会被解析
+
+## 降级行为
+
+- `a < b`、`2<3`、`<3` 等非法标签原样显示
+- `\<b>` 反斜杠转义后原样显示
+- 未闭合的标签自动闭合到文本 / 输入末尾——流式输出中途的 `<b>partial` 会即时渲染为加粗，收到 `</b>` 后自然收敛
+- 游离的闭合标签（如无配对的 `</b>`）被静默忽略
+
+## 已知限制
+
+- HTML 实体（`&amp;` 等）暂不解码
+- `kbd` / `sub` / `sup` / `img` 以 WidgetSpan 渲染，在选择模式下不可选中（与行内图片同类限制）
+- 嵌套的文字装饰（如 `<u><s>x</s></u>`）内层覆盖外层，不叠加
+- 块级 `align` 对齐的是整个内容块，不改变段落内每行文字的对齐
+- 编辑器所见即所得模式（WYSIWYG）暂未接入 `enableHtml`，仅预览模式生效
+
+## 主题定制
+
+新增的样式字段（均可空，`light()` / `dark()` 已填充默认值）：
+
+```dart
+MarkdownStyleSheet.light().copyWith(
+  underlineStyle: ...,   // <u>
+  highlightStyle: ...,   // <mark>
+  kbdStyle: ...,         // <kbd>
+  subscriptStyle: ...,   // <sub>
+  superscriptStyle: ..., // <sup>
+)
+```

--- a/doc/核心需求文档.md
+++ b/doc/核心需求文档.md
@@ -77,9 +77,10 @@ Flutter Smooth Markdown 是一个高效、流畅的 Markdown 渲染器，专为 
 - [x] 响应式表格布局
 
 **HTML 支持：**
-- [x] 内联 HTML 标签
-- [x] HTML 实体转义
-- [x] 安全过滤（防止 XSS）
+- [x] 内联 HTML 标签（白名单：b/strong、i/em、u/ins、s/del/strike、mark、sub、sup、kbd、code、br、a、img、font、span）
+- [x] 块级 HTML 标签（div、p、center、blockquote、hr、details/summary）
+- [ ] HTML 实体转义（`&amp;` 等实体暂不解码）
+- [x] 安全过滤（防止 XSS：标签白名单 + URL scheme 校验 + 样式安全子集，默认关闭需 `enableHtml: true`）
 
 #### 2.2.3 扩展语法（可选）
 

--- a/docs/superpowers/plans/2026-07-30-html-parser-module-refactor.md
+++ b/docs/superpowers/plans/2026-07-30-html-parser-module-refactor.md
@@ -1,0 +1,865 @@
+# HTML Parser Module Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move behavior-preserving inline and block HTML parsing behind two focused internal module interfaces without changing public interfaces, AST output, rendering, security, fallbacks, or streaming behavior.
+
+**Architecture:** `InlineParser` and `BlockParser` retain Markdown precedence and feature gating, then delegate HTML-specific work to `HtmlInlineParser` and `HtmlBlockParser`. Both new modules receive callbacks for nested Markdown parsing, while `html_utils.dart` remains the pure lexer and sanitizer layer.
+
+**Tech Stack:** Dart 3, Flutter, `flutter_test`, the package's custom Markdown AST and parser.
+
+---
+
+## File Map
+
+- Create `lib/src/parser/html/html_inline_parser.dart`: inline HTML matching,
+  sanitization fallback, and AST construction.
+- Create `test/parser/html_inline_parser_test.dart`: direct tests of the inline
+  HTML module interface.
+- Modify `lib/src/parser/inline_parser.dart`: construct and call the inline HTML
+  module; remove HTML-specific implementation details.
+- Create `lib/src/parser/html/html_block_parser.dart`: block HTML probing,
+  multiline scanning, alignment parsing, and AST construction.
+- Create `test/parser/html_block_parser_test.dart`: direct tests of the block
+  HTML module interface.
+- Modify `lib/src/parser/block_parser.dart`: construct and call the block HTML
+  module; remove HTML-specific implementation details.
+- Do not modify renderers, AST definitions, public exports, configuration,
+  style sheets, `StreamMarkdown`, or user-facing documentation.
+
+### Task 1: Extract The Inline HTML Parser Module
+
+**Files:**
+- Create: `test/parser/html_inline_parser_test.dart`
+- Create: `lib/src/parser/html/html_inline_parser.dart`
+- Modify: `lib/src/parser/inline_parser.dart:1-35`
+- Modify: `lib/src/parser/inline_parser.dart:115-130`
+- Modify: `lib/src/parser/inline_parser.dart:638-844`
+- Modify: `lib/src/parser/inline_parser.dart:885-894`
+
+- [ ] **Step 1: Write the failing direct module tests**
+
+Create `test/parser/html_inline_parser_test.dart`:
+
+```dart
+import 'package:flutter_smooth_markdown/flutter_smooth_markdown.dart';
+import 'package:flutter_smooth_markdown/src/parser/html/html_inline_parser.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('HtmlInlineParser', () {
+    late HtmlInlineParser parser;
+
+    setUp(() {
+      parser = HtmlInlineParser(
+        parseChildren: (source, depth) => <MarkdownNode>[
+          TextNode('$depth:$source'),
+        ],
+      );
+    });
+
+    test('returns null for text that is not a valid tag', () {
+      expect(parser.tryParse('< b>', 0, 0), isNull);
+    });
+
+    test('returns nodes and a positive consumed count for a valid tag', () {
+      final result = parser.tryParse('<b>x</b>tail', 0, 0);
+
+      expect(result, isNotNull);
+      expect(result!.consumed, 8);
+      expect(result.consumed, greaterThan(0));
+      final bold = result.nodes.single as BoldNode;
+      expect((bold.children.single as TextNode).content, '1:x');
+    });
+
+    test('splices children from an unknown tag', () {
+      final result = parser.tryParse('<video>x</video>', 0, 0)!;
+
+      expect(result.nodes, hasLength(1));
+      expect((result.nodes.single as TextNode).content, '1:x');
+    });
+
+    test('keeps child text when an anchor URL is unsafe', () {
+      final result = parser.tryParse(
+        '<a href="javascript:alert(1)">click</a>',
+        0,
+        0,
+      )!;
+
+      expect(result.nodes.whereType<LinkNode>(), isEmpty);
+      expect((result.nodes.single as TextNode).content, '1:click');
+    });
+
+    test('uses alt text when an image URL is unsafe', () {
+      final result = parser.tryParse(
+        '<img src="javascript:x" alt="fallback">',
+        0,
+        0,
+      )!;
+
+      expect(result.nodes.whereType<ImageNode>(), isEmpty);
+      expect((result.nodes.single as TextNode).content, 'fallback');
+    });
+
+    test('auto closes an incomplete paired tag at input end', () {
+      const source = '<mark>partial';
+      final result = parser.tryParse(source, 0, 0)!;
+
+      expect(result.consumed, source.length);
+      final mark = result.nodes.single as HighlightNode;
+      expect((mark.children.single as TextNode).content, '1:partial');
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the new test and verify that it fails**
+
+Run:
+
+```bash
+flutter test --no-pub test/parser/html_inline_parser_test.dart
+```
+
+Expected: FAIL because
+`package:flutter_smooth_markdown/src/parser/html/html_inline_parser.dart` and
+`HtmlInlineParser` do not exist.
+
+- [ ] **Step 3: Create the inline HTML module**
+
+Create `lib/src/parser/html/html_inline_parser.dart` with this interface and
+move the current HTML method bodies into it:
+
+```dart
+import '../ast/html_nodes.dart';
+import '../ast/markdown_node.dart';
+import 'html_utils.dart';
+
+/// Parses nested inline Markdown inside an HTML element.
+typedef HtmlInlineChildrenParser = List<MarkdownNode> Function(
+  String source,
+  int depth,
+);
+
+/// Result of parsing one inline HTML tag.
+class HtmlInlineParseResult {
+  /// Creates an inline HTML parse result.
+  const HtmlInlineParseResult({
+    required this.nodes,
+    required this.consumed,
+  });
+
+  /// Nodes generated by the tag, or its children when the tag is stripped.
+  final List<MarkdownNode> nodes;
+
+  /// Number of source characters consumed from the supplied start offset.
+  final int consumed;
+}
+
+/// Internal parser for whitelisted inline HTML.
+class HtmlInlineParser {
+  /// Creates a parser that delegates nested Markdown to [parseChildren].
+  const HtmlInlineParser({required HtmlInlineChildrenParser parseChildren})
+      : _parseChildren = parseChildren;
+
+  final HtmlInlineChildrenParser _parseChildren;
+
+  /// Attempts to parse an HTML tag at [start].
+  ///
+  /// Returns `null` for invalid tag syntax so callers can preserve `<` as
+  /// literal text. A successful result always consumes at least one character.
+  HtmlInlineParseResult? tryParse(String text, int start, int depth) {
+    final tag = lexHtmlTag(text, start);
+    if (tag == null) return null;
+
+    final openConsumed = tag.end - start;
+    if (tag.isClosing) {
+      return HtmlInlineParseResult(
+        nodes: const <MarkdownNode>[],
+        consumed: openConsumed,
+      );
+    }
+
+    final name = tag.name;
+    if (htmlVoidTags.contains(name)) {
+      return switch (name) {
+        'br' => HtmlInlineParseResult(
+            nodes: const <MarkdownNode>[HardBreakNode()],
+            consumed: openConsumed,
+          ),
+        'img' => HtmlInlineParseResult(
+            nodes: _buildImageNodes(tag),
+            consumed: openConsumed,
+          ),
+        _ => HtmlInlineParseResult(
+            nodes: const <MarkdownNode>[],
+            consumed: openConsumed,
+          ),
+      };
+    }
+
+    if (tag.isSelfClosing) {
+      return HtmlInlineParseResult(
+        nodes: const <MarkdownNode>[],
+        consumed: openConsumed,
+      );
+    }
+
+    final contentStart = tag.end;
+    final close = findHtmlCloseTag(text, contentStart, name);
+    final contentEnd = close?.start ?? text.length;
+    final consumed = (close?.end ?? text.length) - start;
+    final inner = text.substring(contentStart, contentEnd);
+
+    if (name == 'code') {
+      return HtmlInlineParseResult(
+        nodes: <MarkdownNode>[InlineCodeNode(inner)],
+        consumed: consumed,
+      );
+    }
+
+    final children = _parseChildren(inner, depth + 1);
+    final node = _buildInlineNode(name, tag.attributes, children);
+    return HtmlInlineParseResult(
+      nodes: node == null ? children : <MarkdownNode>[node],
+      consumed: consumed,
+    );
+  }
+
+  MarkdownNode? _buildInlineNode(
+    String name,
+    Map<String, String> attributes,
+    List<MarkdownNode> children,
+  ) {
+    switch (name) {
+      case 'b':
+      case 'strong':
+        return BoldNode(children);
+      case 'i':
+      case 'em':
+        return ItalicNode(children);
+      case 's':
+      case 'del':
+      case 'strike':
+        return StrikethroughNode(children);
+      case 'u':
+      case 'ins':
+        return UnderlineNode(children);
+      case 'mark':
+        return HighlightNode(children);
+      case 'sub':
+        return SubscriptNode(children);
+      case 'sup':
+        return SuperscriptNode(children);
+      case 'kbd':
+        return KbdNode(children);
+      case 'a':
+        return _buildLinkNode(attributes, children);
+      case 'font':
+      case 'span':
+        return _buildStyledSpanNode(name, attributes, children);
+      default:
+        return null;
+    }
+  }
+
+  MarkdownNode? _buildLinkNode(
+    Map<String, String> attributes,
+    List<MarkdownNode> children,
+  ) {
+    final href = attributes['href'];
+    if (href == null || href.isEmpty || !isSafeHtmlUrl(href)) return null;
+    final title = attributes['title'];
+    return LinkNode(
+      url: href,
+      children: children,
+      title: title == null || title.isEmpty ? null : title,
+    );
+  }
+
+  MarkdownNode? _buildStyledSpanNode(
+    String name,
+    Map<String, String> attributes,
+    List<MarkdownNode> children,
+  ) {
+    int? color;
+    int? backgroundColor;
+    double? fontSize;
+
+    if (name == 'font') {
+      final colorAttribute = attributes['color'];
+      final sizeAttribute = attributes['size'];
+      if (colorAttribute != null) color = parseHtmlColor(colorAttribute);
+      if (sizeAttribute != null) fontSize = parseFontSizeAttr(sizeAttribute);
+    } else {
+      final style = attributes['style'];
+      if (style != null) {
+        final declarations = parseInlineCssDeclarations(style);
+        final colorValue = declarations['color'];
+        final backgroundValue = declarations['background-color'];
+        final sizeValue = declarations['font-size'];
+        if (colorValue != null) color = parseHtmlColor(colorValue);
+        if (backgroundValue != null) {
+          backgroundColor = parseHtmlColor(backgroundValue);
+        }
+        if (sizeValue != null) fontSize = parseHtmlFontSize(sizeValue);
+      }
+    }
+
+    if (color == null && backgroundColor == null && fontSize == null) {
+      return null;
+    }
+    return StyledSpanNode(
+      children: children,
+      color: color,
+      backgroundColor: backgroundColor,
+      fontSize: fontSize,
+    );
+  }
+
+  List<MarkdownNode> _buildImageNodes(HtmlTag tag) {
+    final src = tag.attributes['src'] ?? '';
+    final alt = tag.attributes['alt'] ?? '';
+    if (src.isEmpty || !isSafeHtmlUrl(src)) {
+      return alt.isEmpty ? const <MarkdownNode>[] : <MarkdownNode>[TextNode(alt)];
+    }
+    final title = tag.attributes['title'];
+    final width = tag.attributes['width'];
+    final height = tag.attributes['height'];
+    return <MarkdownNode>[
+      ImageNode(
+        url: src,
+        alt: alt,
+        title: title == null || title.isEmpty ? null : title,
+        width: width == null ? null : parseHtmlDimension(width),
+        height: height == null ? null : parseHtmlDimension(height),
+      ),
+    ];
+  }
+}
+```
+
+Keep all mappings and fallback decisions identical to the methods currently in
+`InlineParser`; only ownership changes.
+
+- [ ] **Step 4: Delegate from `InlineParser` and remove its HTML implementation**
+
+Replace the HTML imports with the new module import:
+
+```dart
+import 'ast/markdown_node.dart';
+import 'html/html_inline_parser.dart';
+import 'parser_plugin.dart';
+```
+
+Change the constructor and add the nullable module field:
+
+```dart
+InlineParser({ParserPluginRegistry? plugins, bool enableHtml = false})
+    : _plugins = plugins,
+      _enableHtml = enableHtml {
+  _htmlParser = enableHtml
+      ? HtmlInlineParser(
+          parseChildren: (source, depth) => parse(source, depth: depth),
+        )
+      : null;
+}
+
+late final HtmlInlineParser? _htmlParser;
+```
+
+At the current HTML decision point, replace `_tryParseHtmlTag` with:
+
+```dart
+final result = _htmlParser!.tryParse(text, i, depth);
+if (result != null) {
+  assert(result.consumed > 0, 'HTML parsing must consume input');
+  nodes.addAll(result.nodes);
+  i += result.consumed;
+  continue;
+}
+```
+
+Delete `_tryParseHtmlTag`, `_buildHtmlInlineNode`, `_buildHtmlLinkNode`,
+`_buildStyledSpanNode`, `_buildHtmlImageNodes`, and `_HtmlParseResult` from
+`inline_parser.dart`. Keep `_canStartHtmlTag` in `InlineParser` because it is
+part of the general parser's fast-path and plain-text scanning policy.
+
+- [ ] **Step 5: Format and run inline tests**
+
+Run:
+
+```bash
+dart format lib/src/parser/html/html_inline_parser.dart \
+  lib/src/parser/inline_parser.dart \
+  test/parser/html_inline_parser_test.dart
+flutter test --no-pub test/parser/html_inline_parser_test.dart \
+  test/parser/html_inline_test.dart \
+  test/parser/html_utils_test.dart
+dart analyze lib/src/parser/html/html_inline_parser.dart \
+  lib/src/parser/inline_parser.dart \
+  test/parser/html_inline_parser_test.dart
+```
+
+Expected: formatting succeeds, all inline HTML tests pass, and analysis reports
+`No issues found!`.
+
+- [ ] **Step 6: Commit the inline module extraction**
+
+```bash
+git add lib/src/parser/html/html_inline_parser.dart \
+  lib/src/parser/inline_parser.dart \
+  test/parser/html_inline_parser_test.dart
+git commit -m "refactor: extract inline HTML parser"
+```
+
+### Task 2: Extract The Block HTML Parser Module
+
+**Files:**
+- Create: `test/parser/html_block_parser_test.dart`
+- Create: `lib/src/parser/html/html_block_parser.dart`
+- Modify: `lib/src/parser/block_parser.dart:1-55`
+- Modify: `lib/src/parser/block_parser.dart:129-150`
+- Modify: `lib/src/parser/block_parser.dart:682-720`
+- Modify: `lib/src/parser/block_parser.dart:901-1028`
+
+- [ ] **Step 1: Write the failing direct module tests**
+
+Create `test/parser/html_block_parser_test.dart`:
+
+```dart
+import 'package:flutter_smooth_markdown/flutter_smooth_markdown.dart';
+import 'package:flutter_smooth_markdown/src/parser/html/html_block_parser.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('HtmlBlockParser', () {
+    late List<String> parsedSources;
+    late HtmlBlockParser parser;
+
+    setUp(() {
+      parsedSources = <String>[];
+      parser = HtmlBlockParser(
+        parseChildren: (source) {
+          parsedSources.add(source);
+          return <MarkdownNode>[
+            ParagraphNode(<MarkdownNode>[TextNode(source)]),
+          ];
+        },
+      );
+    });
+
+    test('probes standalone hr without treating mid-line html as a block', () {
+      expect(parser.probe('  <hr />  '), isA<HtmlHorizontalRuleMatch>());
+      expect(parser.probe('before <div>x</div>'), isNull);
+      expect(parser.probe('< div>'), isNull);
+    });
+
+    test('probe carries the lexed opening tag into block parsing', () {
+      final match = parser.probe('<div align="right">')
+          as HtmlContainerBlockMatch;
+
+      expect(match.openTag.name, 'div');
+      expect(match.openTag.attributes['align'], 'right');
+      final result = parser.parseBlock(
+        <String>['<div align="right">', 'text', '</div>'],
+        0,
+        match,
+      );
+
+      final node = result.node as HtmlBlockNode;
+      expect(node.align, HtmlBlockAlignment.right);
+      expect(result.linesConsumed, 3);
+      expect(parsedSources, <String>['text']);
+    });
+
+    test('tracks same-name nesting across lines', () {
+      final lines = <String>[
+        '<div>',
+        '<div>',
+        'inner',
+        '</div>',
+        'outer',
+        '</div>',
+      ];
+      final match = parser.probe(lines.first) as HtmlContainerBlockMatch;
+
+      final result = parser.parseBlock(lines, 0, match);
+
+      expect(result.linesConsumed, lines.length);
+      expect(parsedSources.single, contains('<div>'));
+      expect(parsedSources.single, contains('outer'));
+    });
+
+    test('keeps content after the terminating close tag', () {
+      const line = '<div>a</div><div>b</div>';
+      final match = parser.probe(line) as HtmlContainerBlockMatch;
+
+      parser.parseBlock(<String>[line], 0, match);
+
+      expect(parsedSources.single, 'a\n<div>b</div>');
+    });
+
+    test('consumes an incomplete block through input end', () {
+      final lines = <String>['<div>', 'rest', 'more'];
+      final match = parser.probe(lines.first) as HtmlContainerBlockMatch;
+
+      final result = parser.parseBlock(lines, 0, match);
+
+      expect(result.linesConsumed, lines.length);
+      expect(parsedSources.single, 'rest\nmore');
+    });
+
+    test('maps blockquote to the existing markdown node', () {
+      final lines = <String>['<blockquote>', 'quote', '</blockquote>'];
+      final match = parser.probe(lines.first) as HtmlContainerBlockMatch;
+
+      final result = parser.parseBlock(lines, 0, match);
+
+      expect(result.node, isA<BlockquoteNode>());
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the new test and verify that it fails**
+
+Run:
+
+```bash
+flutter test --no-pub test/parser/html_block_parser_test.dart
+```
+
+Expected: FAIL because
+`package:flutter_smooth_markdown/src/parser/html/html_block_parser.dart` and
+the block HTML module types do not exist.
+
+- [ ] **Step 3: Create the block HTML module**
+
+Create `lib/src/parser/html/html_block_parser.dart`:
+
+```dart
+import '../ast/html_nodes.dart';
+import '../ast/markdown_node.dart';
+import 'html_utils.dart';
+
+/// Parses nested block Markdown inside an HTML block.
+typedef HtmlBlockChildrenParser = List<MarkdownNode> Function(String source);
+
+/// A recognized HTML line that may interrupt normal paragraph parsing.
+sealed class HtmlBlockMatch {
+  const HtmlBlockMatch();
+}
+
+/// Match for a standalone HTML horizontal rule.
+final class HtmlHorizontalRuleMatch extends HtmlBlockMatch {
+  /// Creates a horizontal-rule match.
+  const HtmlHorizontalRuleMatch();
+}
+
+/// Match for a whitelisted container block.
+final class HtmlContainerBlockMatch extends HtmlBlockMatch {
+  /// Creates a match carrying the normalized line and lexed opening tag.
+  const HtmlContainerBlockMatch({
+    required this.firstLine,
+    required this.openTag,
+  });
+
+  /// Trimmed first source line used by block parsing.
+  final String firstLine;
+
+  /// Opening tag lexed during probing and reused during block parsing.
+  final HtmlTag openTag;
+}
+
+/// Result of parsing one HTML block.
+class HtmlBlockParseResult {
+  /// Creates a block HTML parse result.
+  const HtmlBlockParseResult({
+    required this.node,
+    required this.linesConsumed,
+  });
+
+  /// Existing Markdown AST node generated for the block.
+  final MarkdownNode node;
+
+  /// Number of source lines consumed.
+  final int linesConsumed;
+}
+
+/// Internal parser for whitelisted block HTML.
+class HtmlBlockParser {
+  /// Creates a parser that delegates nested Markdown to [parseChildren].
+  const HtmlBlockParser({required HtmlBlockChildrenParser parseChildren})
+      : _parseChildren = parseChildren;
+
+  static final RegExp _blockStartPattern = RegExp(
+    r'^<(?:div|p|center|blockquote)\b',
+    caseSensitive: false,
+  );
+  static final RegExp _horizontalRulePattern = RegExp(
+    r'^<hr\s*/?>$',
+    caseSensitive: false,
+  );
+
+  final HtmlBlockChildrenParser _parseChildren;
+
+  /// Recognizes a supported HTML block marker at the start of [line].
+  HtmlBlockMatch? probe(String line) {
+    if (!_couldStartHtmlLine(line)) return null;
+    final trimmed = line.trim();
+    if (_horizontalRulePattern.hasMatch(trimmed)) {
+      return const HtmlHorizontalRuleMatch();
+    }
+    if (!_blockStartPattern.hasMatch(trimmed)) return null;
+    final openTag = lexHtmlTag(trimmed, 0);
+    if (openTag == null || openTag.isClosing) return null;
+    return HtmlContainerBlockMatch(firstLine: trimmed, openTag: openTag);
+  }
+
+  /// Parses a block previously recognized by [probe].
+  HtmlBlockParseResult parseBlock(
+    List<String> lines,
+    int startIndex,
+    HtmlContainerBlockMatch match,
+  ) {
+    assert(startIndex >= 0 && startIndex < lines.length);
+    assert(lines[startIndex].trim() == match.firstLine);
+
+    final openTag = match.openTag;
+    final tagName = openTag.name;
+    final align = _parseAlignment(openTag);
+    if (openTag.isSelfClosing) {
+      return HtmlBlockParseResult(
+        node: _buildBlockNode(tagName, const <MarkdownNode>[], align),
+        linesConsumed: 1,
+      );
+    }
+
+    final contentLines = <String>[];
+    var nesting = 1;
+    var lineIndex = startIndex;
+    while (lineIndex < lines.length) {
+      final isFirst = lineIndex == startIndex;
+      final lineText = isFirst ? match.firstLine : lines[lineIndex];
+      final from = isFirst ? openTag.end : 0;
+      final scan = scanHtmlCloseTag(
+        lineText,
+        from,
+        tagName,
+        initialNesting: nesting,
+      );
+      nesting = scan.nesting;
+
+      final close = scan.close;
+      if (close != null) {
+        final before = lineText.substring(from, close.start);
+        final after = lineText.substring(close.end);
+        if (before.trim().isNotEmpty) contentLines.add(before);
+        if (after.trim().isNotEmpty) contentLines.add(after);
+        lineIndex++;
+        break;
+      }
+
+      final content = lineText.substring(from);
+      if (!isFirst || content.trim().isNotEmpty) contentLines.add(content);
+      lineIndex++;
+    }
+
+    final source = contentLines.join('\n');
+    final children = source.trim().isEmpty
+        ? const <MarkdownNode>[]
+        : _parseChildren(source);
+    return HtmlBlockParseResult(
+      node: _buildBlockNode(tagName, children, align),
+      linesConsumed: lineIndex - startIndex,
+    );
+  }
+
+  static bool _couldStartHtmlLine(String line) {
+    if (line.isEmpty) return false;
+    final first = line.codeUnitAt(0);
+    return first <= 0x20 || first == 0x3C;
+  }
+
+  static HtmlBlockAlignment? _parseAlignment(HtmlTag tag) {
+    if (tag.name == 'center') return HtmlBlockAlignment.center;
+    return switch (tag.attributes['align']?.toLowerCase()) {
+      'left' => HtmlBlockAlignment.left,
+      'center' => HtmlBlockAlignment.center,
+      'right' => HtmlBlockAlignment.right,
+      _ => null,
+    };
+  }
+
+  static MarkdownNode _buildBlockNode(
+    String tag,
+    List<MarkdownNode> children,
+    HtmlBlockAlignment? align,
+  ) {
+    if (tag == 'blockquote') return BlockquoteNode(children);
+    return HtmlBlockNode(tag: tag, children: children, align: align);
+  }
+}
+```
+
+- [ ] **Step 4: Delegate from `BlockParser` and remove its HTML implementation**
+
+Use these imports:
+
+```dart
+import 'ast/markdown_node.dart';
+import 'html/html_block_parser.dart';
+import 'inline_parser.dart';
+import 'parser_plugin.dart';
+```
+
+Construct the module only when HTML is enabled:
+
+```dart
+BlockParser({ParserPluginRegistry? plugins, bool enableHtml = false})
+    : _plugins = plugins,
+      _inlineParser = InlineParser(plugins: plugins, enableHtml: enableHtml) {
+  _htmlParser = enableHtml
+      ? HtmlBlockParser(parseChildren: parse)
+      : null;
+}
+
+late final HtmlBlockParser? _htmlParser;
+```
+
+After the dedicated `details` branch and before table parsing, probe once and
+dispatch by match type:
+
+```dart
+final htmlMatch = node == null ? _htmlParser?.probe(line) : null;
+if (node == null && htmlMatch is HtmlHorizontalRuleMatch) {
+  node = const HorizontalRuleNode();
+  consumed = 1;
+}
+if (node == null && htmlMatch is HtmlContainerBlockMatch) {
+  final result = _htmlParser!.parseBlock(lines, i, htmlMatch);
+  node = result.node;
+  consumed = result.linesConsumed;
+}
+```
+
+Replace the two HTML checks in `_parseParagraph` with one probe:
+
+```dart
+final startsHtmlBlock = _htmlParser?.probe(line) != null;
+if (_isHeader(line) ||
+    _isCodeBlockStart(line) ||
+    _isBlockMathStart(line) ||
+    _isBlockquote(line) ||
+    _isListItem(line) ||
+    _isHorizontalRule(line) ||
+    _isFootnoteDefinition(line) ||
+    _isTableStart(lines, i) ||
+    startsHtmlBlock) {
+  break;
+}
+```
+
+Delete `_htmlBlockStartPattern`, `_htmlHrPattern`, `_enableHtml`,
+`_isHtmlHrLine`, `_isHtmlBlockStart`, `_couldStartHtmlLine`, `_parseHtmlBlock`,
+`_parseHtmlBlockAlignment`, and `_buildHtmlBlockNode` from `block_parser.dart`.
+Keep the dedicated details parser unchanged and before HTML probing.
+
+- [ ] **Step 5: Format and run block tests**
+
+Run:
+
+```bash
+dart format lib/src/parser/html/html_block_parser.dart \
+  lib/src/parser/block_parser.dart \
+  test/parser/html_block_parser_test.dart
+flutter test --no-pub test/parser/html_block_parser_test.dart \
+  test/parser/html_block_test.dart \
+  test/integration/html_integration_test.dart
+dart analyze lib/src/parser/html/html_block_parser.dart \
+  lib/src/parser/block_parser.dart \
+  test/parser/html_block_parser_test.dart
+```
+
+Expected: all block and integration tests pass and analysis reports
+`No issues found!`.
+
+- [ ] **Step 6: Commit the block module extraction**
+
+```bash
+git add lib/src/parser/html/html_block_parser.dart \
+  lib/src/parser/block_parser.dart \
+  test/parser/html_block_parser_test.dart
+git commit -m "refactor: extract block HTML parser"
+```
+
+### Task 3: Verify The Complete Behavior-Preserving Refactor
+
+**Files:**
+- Verify: `lib/src/parser/html/html_utils.dart`
+- Verify: `lib/src/parser/html/html_inline_parser.dart`
+- Verify: `lib/src/parser/html/html_block_parser.dart`
+- Verify: `lib/src/parser/inline_parser.dart`
+- Verify: `lib/src/parser/block_parser.dart`
+- Verify: all HTML-focused and repository tests
+
+- [ ] **Step 1: Confirm ownership moved to the intended modules**
+
+Run:
+
+```bash
+rg -n "_tryParseHtmlTag|_buildHtmlInlineNode|_buildHtmlLinkNode|_buildStyledSpanNode|_buildHtmlImageNodes|_parseHtmlBlock|_parseHtmlBlockAlignment|_buildHtmlBlockNode|scanHtmlCloseTag|lexHtmlTag|isSafeHtmlUrl|parseHtmlColor|parseHtmlDimension" \
+  lib/src/parser/inline_parser.dart \
+  lib/src/parser/block_parser.dart
+```
+
+Expected: no matches. The general parsers should contain only module
+construction, fast-path gating, probing, delegation, and result handling.
+
+- [ ] **Step 2: Run the focused HTML suite and benchmarks**
+
+Run:
+
+```bash
+flutter test --no-pub \
+  test/parser/html_utils_test.dart \
+  test/parser/html_nodes_test.dart \
+  test/parser/html_inline_parser_test.dart \
+  test/parser/html_inline_test.dart \
+  test/parser/html_block_parser_test.dart \
+  test/parser/html_block_test.dart \
+  test/renderer/html_builder_test.dart \
+  test/integration/html_integration_test.dart \
+  test/performance/html_parse_benchmark_test.dart
+```
+
+Expected: all tests pass. The existing generous performance assertions pass;
+do not convert one local timing sample into a stricter threshold.
+
+- [ ] **Step 3: Run full repository validation**
+
+Run:
+
+```bash
+flutter analyze --no-pub
+flutter test --no-pub
+git diff --check
+```
+
+Expected: analysis reports no issues, the complete test suite passes, and
+`git diff --check` prints no output.
+
+- [ ] **Step 4: Inspect the final branch state**
+
+Run:
+
+```bash
+git status --short --branch
+git log -3 --oneline --decorate
+```
+
+Expected: the worktree is clean. The latest commits are the block extraction,
+inline extraction, and implementation plan commits, in that order, with the
+design document immediately before them. Do not push the branch unless the
+user explicitly requests it.

--- a/docs/superpowers/specs/2026-07-30-html-parser-module-refactor-design.md
+++ b/docs/superpowers/specs/2026-07-30-html-parser-module-refactor-design.md
@@ -1,0 +1,181 @@
+# HTML Parser Module Refactor Design
+
+## Context
+
+HTML support currently spans `InlineParser`, `BlockParser`, pure HTML helpers,
+HTML AST nodes, and renderer builders. The behavior is well covered and the
+current performance baseline is healthy, but HTML-specific parsing and AST
+construction still live inside the general Markdown parsers. This makes those
+parsers harder to navigate and requires maintainers to understand unrelated
+HTML rules when changing core Markdown parsing.
+
+This refactor moves HTML parsing behind two internal module interfaces while
+preserving all public and observable behavior.
+
+## Goals
+
+- Concentrate inline HTML behavior in one internal module.
+- Concentrate block HTML behavior in one internal module.
+- Keep pure lexing and sanitization helpers platform independent.
+- Reduce HTML-specific responsibilities in `InlineParser` and `BlockParser`.
+- Avoid repeated lexing of a block's opening tag after it has been recognized.
+- Preserve the current public interface, AST, rendering, security, fallback,
+  and streaming behavior.
+
+## Non-goals
+
+- Adding tags, attributes, CSS properties, or HTML entity decoding.
+- Changing `MarkdownConfig.enableHtml` or its default value.
+- Changing HTML AST node types, renderer builders, or style configuration.
+- Moving the existing `details` and `summary` path into the opt-in HTML parser.
+- Changing output for malformed, unsafe, unknown, or incomplete HTML.
+- Claiming a large parsing performance improvement from a structural refactor.
+
+## Architecture
+
+### Inline HTML module
+
+Add `lib/src/parser/html/html_inline_parser.dart` with an internal
+`HtmlInlineParser` module. Its interface accepts source text, a start offset,
+the current nesting depth, and an internal callback that parses child inline
+Markdown. It returns either no match or an `HtmlInlineParseResult` containing
+the generated nodes and consumed character count.
+
+Its implementation owns:
+
+- matching paired, void, self-closing, stray closing, and incomplete tags;
+- mapping whitelisted formatting tags to existing AST nodes;
+- stripping unknown tags while preserving parsed child content;
+- creating safe links, images, and styled spans;
+- applying the existing unsafe URL and invalid attribute fallbacks;
+- preserving verbatim content for HTML `code` tags.
+
+`InlineParser` retains Markdown precedence, the `enableHtml` guard, the cheap
+`<` start check, and recursion depth policy. At the existing HTML decision
+point it delegates to `HtmlInlineParser` and appends the returned nodes.
+
+### Block HTML module
+
+Add `lib/src/parser/html/html_block_parser.dart` with an internal
+`HtmlBlockParser` module. It exposes a lightweight line probe and a block parse
+operation. A successful probe carries the already-lexed opening tag so block
+parsing does not lex the same tag again.
+
+Its implementation owns:
+
+- recognizing standalone HTML `hr` lines and whitelisted block starts;
+- scanning same-name nesting across lines;
+- preserving text before and after the terminating close tag;
+- consuming incomplete blocks through the end of the current input;
+- parsing the `align` attribute and the implicit `center` alignment;
+- mapping HTML `blockquote` to the existing `BlockquoteNode`;
+- creating the existing `HtmlBlockNode` for other supported block tags.
+
+The module receives an internal callback for parsing block child Markdown.
+`BlockParser` retains Markdown block precedence and decides when to probe HTML.
+Paragraph termination uses the same lightweight probe contract.
+
+### HTML utilities
+
+Keep `lib/src/parser/html/html_utils.dart` limited to stateless, pure Dart
+lexing and safety functions. It continues to own tag lexing, close-tag scans,
+URL checks, color and dimension parsing, and inline CSS declaration parsing.
+It does not construct AST nodes or orchestrate Markdown parsing.
+
+### Unchanged layers
+
+`MarkdownParser`, HTML AST nodes, renderer builders, `StreamMarkdown`, public
+exports, configuration, and theme fields remain unchanged. The refactor stops
+at the parser's internal module seams.
+
+## Data Flow
+
+```text
+MarkdownParser
+  -> BlockParser
+       -> HtmlBlockParser
+       -> InlineParser
+            -> HtmlInlineParser
+  -> existing AST
+  -> existing renderer
+```
+
+When HTML is disabled, the general parsers do not invoke the HTML modules.
+When inline parsing encounters a plausible `<`, `HtmlInlineParser.tryParse`
+either returns no match so `<` remains literal, or returns a result with a
+strictly positive consumed count. Block parsing probes HTML only at the same
+precedence points used today and passes a successful probe into block parsing.
+
+Child content is parsed through callbacks into the existing Markdown parsers.
+The HTML modules do not duplicate Markdown syntax rules and do not depend on
+renderer code.
+
+## Compatibility And Fallbacks
+
+The following behavior is invariant:
+
+- Invalid tags remain literal text.
+- Unknown valid tags are removed while their child content is retained.
+- Unsafe anchors retain their child text without a link node.
+- Unsafe or missing image sources degrade to alt text or no node.
+- Stray closing tags are consumed silently.
+- Explicitly self-closed non-void tags produce no content.
+- Unclosed paired tags consume through the current input end.
+- HTML inside code spans, code blocks, and math remains protected.
+- `details` and `summary` continue through their dedicated parser path.
+- `enableHtml: false` keeps HTML literal and retains the existing fast path.
+
+User-controlled input must not cause parsing exceptions. A block parse
+operation receives a validated probe result; mismatches between those internal
+values are programming errors guarded by assertions rather than user-facing
+exceptions.
+
+## Testing Strategy
+
+Implementation follows characterization-first migration:
+
+1. Add focused interface tests for inline no-match, positive consumption,
+   unknown-tag splicing, unsafe URL fallback, and incomplete-tag behavior.
+2. Add focused interface tests for block probing, reuse of the probed opening
+   tag, nested multiline blocks, trailing same-line content, alignment, and
+   incomplete blocks.
+3. Move the current implementation behind the new interfaces without changing
+   expected AST values.
+4. Keep all existing parser, renderer, integration, streaming, and performance
+   tests passing.
+
+The verification commands are:
+
+```bash
+flutter test test/parser/html_utils_test.dart \
+  test/parser/html_nodes_test.dart \
+  test/parser/html_inline_test.dart \
+  test/parser/html_block_test.dart \
+  test/renderer/html_builder_test.dart \
+  test/integration/html_integration_test.dart \
+  test/performance/html_parse_benchmark_test.dart
+
+dart analyze \
+  lib/src/parser/html/html_utils.dart \
+  lib/src/parser/html/html_inline_parser.dart \
+  lib/src/parser/html/html_block_parser.dart \
+  lib/src/parser/inline_parser.dart \
+  lib/src/parser/block_parser.dart
+
+git diff --check
+```
+
+The existing generous benchmark guards remain the performance acceptance
+criteria. The refactor must not add a stricter timing assertion based on a
+single local run.
+
+## Success Criteria
+
+- `InlineParser` contains no HTML tag-to-AST mapping or HTML attribute logic.
+- `BlockParser` contains no HTML close-tag scanning, alignment parsing, or HTML
+  block AST construction.
+- The two HTML parser modules expose only the information their callers need.
+- No public type, constructor, configuration default, or export changes.
+- Existing HTML behavior and focused tests remain green.
+- Static analysis and whitespace validation pass.
+- Changes remain limited to parser internals and their focused tests.

--- a/example/lib/html_demo.dart
+++ b/example/lib/html_demo.dart
@@ -41,8 +41,47 @@ HTML tags. Toggle the switch in the app bar to compare.
 
 ## Mixing Markdown and HTML
 
+HTML and Markdown can be nested in either direction. These four cases cover
+each combination of inline vs. block on both sides.
+
+### Inline ↔ inline
+
 **Markdown bold with <u>HTML underline</u> inside**, and
 <b>HTML bold with *markdown italic* inside</b>.
+
+### HTML inline inside Markdown structure
+
+HTML tags work inside markdown headers and list items:
+
+#### A header with a tag: Note <sup>2</sup>
+
+- List item with <b>bold</b>, <i>italic</i>, and <mark>mark</mark>
+- Another item with an <a href="https://flutter.dev">HTML link</a> inside
+
+### Markdown inside HTML styling tags
+
+`<font>` and `<span>` run their children back through the markdown inline
+parser, so styling composes with markdown emphasis and code:
+
+- <font color="red">red with **bold** inside</font>
+- <span style="font-size: 22px;">sized with *italic* and `code` inside</span>
+
+### HTML block wrapping Markdown blocks
+
+`<div>` and `<center>` blocks re-parse their contents as markdown blocks, so
+headings, lists, and paragraphs work inside them (the opening tag must sit
+at the start of its own line):
+
+<div>
+
+### A heading inside `<div>`
+
+- a list item inside `<div>`
+- another item with **bold**
+
+A normal paragraph inside `<div>`, with <i>inline HTML</i> too.
+
+</div>
 
 ## Colors and Sizes
 
@@ -84,6 +123,39 @@ An HTML blockquote with *markdown* inside.
 
 Unknown tags are stripped while keeping their content:
 <video>this text is kept, the video tag is not</video>.
+
+## Image `src` Policy
+
+Image sources are constrained by what the renderer can actually load: only
+`http`/`https` and local paths. Schemes that pass link-safety but cannot be
+loaded as images fall back to the alt text instead of a broken placeholder.
+
+- Network image (loads): <img src="https://picsum.photos/320/120" alt="network" width="320" height="120">
+- Protocol-relative URL (rejected → alt text): <img src="//picsum.photos/120/120" alt="protocol-relative">
+- `mailto:` scheme (rejected → alt text): <img src="mailto:a@b.com" alt="mailto-not-an-image">
+- `tel:` scheme (rejected → alt text): <img src="tel:+12345" alt="tel-not-an-image">
+- Unsafe scheme (rejected → alt text): <img src="javascript:alert(1)" alt="javascript-blocked">
+
+## Streaming Tag Withholding
+
+While streaming, a tag split across chunks (e.g. `<font colo` arriving
+before `r="red">`) is withheld until its closing `>` arrives, so the partial
+tag is never flashed as literal text. Tap the play button and watch this
+line render in one piece:
+
+<font color="purple">purple text arrives tag-complete, never as `<font colo`</font>
+
+This withholding only applies when HTML is enabled. Toggle HTML off and
+stream again: the same line, plus prose like `a < b` and `<3 hearts`, must
+still render verbatim without being swallowed mid-stream.
+
+## Non-Breaking Renderer API
+
+`BlockRenderer` stays a plain single-argument `(nodes) => widget` callback,
+so existing custom block renderers keep working. The optional render-context
+override (used, for example, by HTML blocks to apply text alignment) lives
+on a separate additive `ContextualBlockRenderer` typedef — covered by
+`test/renderer/widget_builder_test.dart`.
 
 ## Still Safe
 

--- a/example/lib/html_demo.dart
+++ b/example/lib/html_demo.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_smooth_markdown/flutter_smooth_markdown.dart';
+
+/// Demo page showing HTML tag rendering
+class HtmlDemo extends StatefulWidget {
+  const HtmlDemo({
+    super.key,
+    this.styleSheet,
+  });
+
+  final MarkdownStyleSheet? styleSheet;
+
+  @override
+  State<HtmlDemo> createState() => _HtmlDemoState();
+}
+
+class _HtmlDemoState extends State<HtmlDemo> {
+  bool _enableHtml = true;
+
+  static const String _htmlContent = '''
+# HTML Tags Demo
+
+Enable `MarkdownConfig(enableHtml: true)` to render a safe whitelist of
+HTML tags. Toggle the switch in the app bar to compare.
+
+## Inline Formatting
+
+- Bold: <b>b tag</b> and <strong>strong tag</strong>
+- Italic: <i>i tag</i> and <em>em tag</em>
+- Underline: <u>u tag</u> and <ins>ins tag</ins>
+- Strikethrough: <s>s</s>, <del>del</del>, <strike>strike</strike>
+- Highlight: <mark>marked text</mark>
+- Keyboard: press <kbd>Ctrl</kbd> + <kbd>C</kbd> to copy
+- Code: <code>const x = 1;</code>
+- Sub/sup: H<sub>2</sub>O and E = mc<sup>2</sup>
+- Line break: first line<br>second line
+
+## Mixing Markdown and HTML
+
+**Markdown bold with <u>HTML underline</u> inside**, and
+<b>HTML bold with *markdown italic* inside</b>.
+
+## Colors and Sizes
+
+- <font color="red">font color red</font>
+- <font color="#1E88E5" size="5">font color and size</font>
+- <span style="color: green;">span green</span>
+- <span style="background-color: yellow; color: black;">span highlight</span>
+- <span style="font-size: 22px;">span font size</span>
+
+## Links and Images
+
+- HTML link: <a href="https://flutter.dev" title="Flutter">flutter.dev</a>
+- Unsafe links are stripped: <a href="javascript:alert(1)">safe text only</a>
+- Sized image: <img src="https://picsum.photos/300/150" alt="demo" width="300" height="150">
+
+## Block Elements
+
+<center>
+
+**This block is centered** via `<center>`.
+
+</center>
+
+<div align="right">
+
+Right-aligned via `<div align="right">`.
+
+</div>
+
+<p>A paragraph tag with plain content.</p>
+
+<blockquote>
+An HTML blockquote with *markdown* inside.
+</blockquote>
+
+<hr>
+
+## Unknown Tags
+
+Unknown tags are stripped while keeping their content:
+<video>this text is kept, the video tag is not</video>.
+
+## Still Safe
+
+Plain comparisons stay literal: 1 < 2, a < b, and <3 hearts.
+Inline code is protected: `<b>not bold</b>`.
+''';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('HTML Tags Demo'),
+        actions: [
+          Row(
+            children: [
+              const Text('HTML'),
+              Switch(
+                value: _enableHtml,
+                onChanged: (value) => setState(() => _enableHtml = value),
+              ),
+            ],
+          ),
+        ],
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: SmoothMarkdown(
+          data: _htmlContent,
+          styleSheet: widget.styleSheet,
+          config: MarkdownConfig(enableHtml: _enableHtml),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/html_demo.dart
+++ b/example/lib/html_demo.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_smooth_markdown/flutter_smooth_markdown.dart';
 
@@ -16,6 +18,8 @@ class HtmlDemo extends StatefulWidget {
 
 class _HtmlDemoState extends State<HtmlDemo> {
   bool _enableHtml = true;
+  bool _isStreaming = false;
+  StreamController<String>? _streamController;
 
   static const String _htmlContent = '''
 # HTML Tags Demo
@@ -87,6 +91,52 @@ Plain comparisons stay literal: 1 < 2, a < b, and <3 hearts.
 Inline code is protected: `<b>not bold</b>`.
 ''';
 
+  /// Splits the demo content into word-level chunks with their trailing
+  /// whitespace, approximating how a token stream would arrive.
+  static List<String> _chunkContent(String content) {
+    return RegExp(r'\S+\s*')
+        .allMatches(content)
+        .map((match) => match[0]!)
+        .toList();
+  }
+
+  /// Streams the demo content chunk by chunk to simulate live output.
+  Future<void> _startStreaming() async {
+    if (_isStreaming) return;
+
+    final controller = StreamController<String>();
+    setState(() {
+      _isStreaming = true;
+      _streamController = controller;
+    });
+
+    for (final chunk in _chunkContent(_htmlContent)) {
+      if (!mounted || controller.isClosed) break;
+      controller.add(chunk);
+      await Future.delayed(const Duration(milliseconds: 40));
+    }
+
+    if (mounted) {
+      setState(() => _isStreaming = false);
+      await controller.close();
+    }
+  }
+
+  /// Stops the active stream and returns to the static view.
+  void _stopStreaming() {
+    _streamController?.close();
+    setState(() {
+      _streamController = null;
+      _isStreaming = false;
+    });
+  }
+
+  @override
+  void dispose() {
+    _streamController?.close();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -102,15 +152,35 @@ Inline code is protected: `<b>not bold</b>`.
               ),
             ],
           ),
+          IconButton(
+            tooltip: _isStreaming ? 'Stop streaming' : 'Simulate streaming',
+            icon: Icon(_isStreaming ? Icons.stop : Icons.play_arrow),
+            onPressed: _isStreaming ? _stopStreaming : _startStreaming,
+          ),
         ],
       ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16.0),
-        child: SmoothMarkdown(
-          data: _htmlContent,
-          styleSheet: widget.styleSheet,
-          config: MarkdownConfig(enableHtml: _enableHtml),
-        ),
+      body: Column(
+        children: [
+          if (_isStreaming) const LinearProgressIndicator(),
+          Expanded(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(16.0),
+              child: _streamController == null
+                  ? SmoothMarkdown(
+                      data: _htmlContent,
+                      styleSheet: widget.styleSheet,
+                      config: MarkdownConfig(enableHtml: _enableHtml),
+                    )
+                  : StreamMarkdown(
+                      stream: _streamController!.stream,
+                      styleSheet: widget.styleSheet,
+                      config: MarkdownConfig(enableHtml: _enableHtml),
+                      loadingWidget:
+                          const Center(child: CircularProgressIndicator()),
+                    ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flutter_smooth_markdown/flutter_smooth_markdown.dart';
 import 'ai_chat_demo.dart';
 import 'chat_list_demo.dart';
 import 'footnote_demo.dart';
+import 'html_demo.dart';
 import 'l10n/app_localizations.dart';
 import 'conversation_list_demo.dart';
 import 'editor_demo.dart';
@@ -1280,6 +1281,36 @@ gantt
                     context,
                     MaterialPageRoute(
                       builder: (context) => FootnoteDemo(
+                        styleSheet: _getStyleSheet(),
+                      ),
+                    ),
+                  );
+                },
+              ),
+              ListTile(
+                leading: Icon(
+                  Icons.code,
+                  color: isDark ? Colors.white70 : null,
+                ),
+                title: Text(
+                  'HTML Tags Demo',
+                  style: TextStyle(
+                    color: isDark ? Colors.white : null,
+                  ),
+                ),
+                subtitle: Text(
+                  'Whitelisted HTML rendering',
+                  style: TextStyle(
+                    fontSize: 11,
+                    color: isDark ? Colors.white38 : Colors.grey,
+                  ),
+                ),
+                onTap: () {
+                  Navigator.pop(context);
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => HtmlDemo(
                         styleSheet: _getStyleSheet(),
                       ),
                     ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -6,7 +6,7 @@ packages:
     description:
       name: args
       sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.7.0"
   async:
@@ -14,7 +14,7 @@ packages:
     description:
       name: async
       sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.13.1"
   boolean_selector:
@@ -22,7 +22,7 @@ packages:
     description:
       name: boolean_selector
       sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.2"
   cached_network_image:
@@ -30,7 +30,7 @@ packages:
     description:
       name: cached_network_image
       sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.4.1"
   cached_network_image_platform_interface:
@@ -38,7 +38,7 @@ packages:
     description:
       name: cached_network_image_platform_interface
       sha256: "35814b016e37fbdc91f7ae18c8caf49ba5c88501813f73ce8a07027a395e2829"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "4.1.1"
   cached_network_image_web:
@@ -46,23 +46,23 @@ packages:
     description:
       name: cached_network_image_web
       sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.3.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
-      url: "https://pub.dev"
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
       name: clock
       sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.1.2"
   code_assets:
@@ -70,7 +70,7 @@ packages:
     description:
       name: code_assets
       sha256: bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.2.1"
   collection:
@@ -78,7 +78,7 @@ packages:
     description:
       name: collection
       sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.19.1"
   crypto:
@@ -86,7 +86,7 @@ packages:
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.0.7"
   fake_async:
@@ -94,7 +94,7 @@ packages:
     description:
       name: fake_async
       sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.3.3"
   ffi:
@@ -102,7 +102,7 @@ packages:
     description:
       name: ffi
       sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.2.0"
   file:
@@ -110,7 +110,7 @@ packages:
     description:
       name: file
       sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "7.0.1"
   fixnum:
@@ -118,7 +118,7 @@ packages:
     description:
       name: fixnum
       sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.1.1"
   flutter:
@@ -131,7 +131,7 @@ packages:
     description:
       name: flutter_cache_manager
       sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.4.1"
   flutter_dotenv:
@@ -139,7 +139,7 @@ packages:
     description:
       name: flutter_dotenv
       sha256: b7c7be5cd9f6ef7a78429cabd2774d3c4af50e79cb2b7593e3d5d763ef95c61b
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "5.2.1"
   flutter_highlight:
@@ -147,7 +147,7 @@ packages:
     description:
       name: flutter_highlight
       sha256: "7b96333867aa07e122e245c033b8ad622e4e3a42a1a2372cbb098a2541d8782c"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.7.0"
   flutter_lints:
@@ -155,7 +155,7 @@ packages:
     description:
       name: flutter_lints
       sha256: "5398f14efa795ffb7a33e9b6a08798b26a180edac4ad7db3f231e40f82ce11e1"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "5.0.0"
   flutter_localizations:
@@ -168,7 +168,7 @@ packages:
     description:
       name: flutter_math_fork
       sha256: "6d5f2f1aa57ae539ffb0a04bb39d2da67af74601d685a161aff7ce5bda5fa407"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.7.4"
   flutter_smooth_markdown:
@@ -177,13 +177,13 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.8.0"
+    version: "0.9.0"
   flutter_svg:
     dependency: transitive
     description:
       name: flutter_svg
       sha256: "35882981abcbfb8c15b286f0cd690ff25bac12d95eff3e25ee207f37d4c42e7f"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.3.0"
   flutter_test:
@@ -196,7 +196,7 @@ packages:
     description:
       name: highlight
       sha256: "5353a83ffe3e3eca7df0abfb72dcf3fa66cc56b953728e7113ad4ad88497cf21"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.7.0"
   hooks:
@@ -204,7 +204,7 @@ packages:
     description:
       name: hooks
       sha256: "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.0.2"
   http:
@@ -212,7 +212,7 @@ packages:
     description:
       name: http
       sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.6.0"
   http_parser:
@@ -220,7 +220,7 @@ packages:
     description:
       name: http_parser
       sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "4.1.2"
   intl:
@@ -228,7 +228,7 @@ packages:
     description:
       name: intl
       sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.20.2"
   jni:
@@ -236,7 +236,7 @@ packages:
     description:
       name: jni
       sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.0.0"
   jni_flutter:
@@ -244,7 +244,7 @@ packages:
     description:
       name: jni_flutter
       sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.0.1"
   leak_tracker:
@@ -252,7 +252,7 @@ packages:
     description:
       name: leak_tracker
       sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "11.0.2"
   leak_tracker_flutter_testing:
@@ -260,7 +260,7 @@ packages:
     description:
       name: leak_tracker_flutter_testing
       sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.0.10"
   leak_tracker_testing:
@@ -268,7 +268,7 @@ packages:
     description:
       name: leak_tracker_testing
       sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.0.2"
   lints:
@@ -276,7 +276,7 @@ packages:
     description:
       name: lints
       sha256: c35bb79562d980e9a453fc715854e1ed39e24e7d0297a880ef54e17f9874a9d7
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "5.1.1"
   logging:
@@ -284,39 +284,39 @@ packages:
     description:
       name: logging
       sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.3.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
-      url: "https://pub.dev"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
-      url: "https://pub.dev"
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
-      url: "https://pub.dev"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   nested:
     dependency: transitive
     description:
       name: nested
       sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.0.0"
   objective_c:
@@ -324,7 +324,7 @@ packages:
     description:
       name: objective_c
       sha256: "6cb691c686fa2838c6deb34980d426145c2a5d537491cb83d463c33cdbc726ed"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "9.4.1"
   octo_image:
@@ -332,7 +332,7 @@ packages:
     description:
       name: octo_image
       sha256: "34faa6639a78c7e3cbe79be6f9f96535867e879748ade7d17c9b1ae7536293bd"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.0"
   package_config:
@@ -340,7 +340,7 @@ packages:
     description:
       name: package_config
       sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.2.0"
   path:
@@ -348,7 +348,7 @@ packages:
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.9.1"
   path_parsing:
@@ -356,23 +356,23 @@ packages:
     description:
       name: path_parsing
       sha256: "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.1.0"
   path_provider:
     dependency: transitive
     description:
       name: path_provider
-      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
-      url: "https://pub.dev"
+      sha256: a7f4874f987173da295a61c181b8ee71dab59b332a486b391babf26a1b884825
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.5"
+    version: "2.1.6"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
       sha256: "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.3.1"
   path_provider_foundation:
@@ -380,31 +380,31 @@ packages:
     description:
       name: path_provider_foundation
       sha256: "2a376b7d6392d80cd3705782d2caa734ca4727776db0b6ec36ef3f1855197699"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.6.0"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
-      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
-      url: "https://pub.dev"
+      sha256: "58c2005f147315b11e9b4a7bc889cd5203e250cba8e3f012dae259b4972b5c16"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.2"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
-      url: "https://pub.dev"
+      sha256: "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
       sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.3.0"
   petitparser:
@@ -412,7 +412,7 @@ packages:
     description:
       name: petitparser
       sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "7.0.2"
   platform:
@@ -420,7 +420,7 @@ packages:
     description:
       name: platform
       sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.1.6"
   plugin_platform_interface:
@@ -428,7 +428,7 @@ packages:
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.8"
   provider:
@@ -436,7 +436,7 @@ packages:
     description:
       name: provider
       sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "6.1.5+1"
   pub_semver:
@@ -444,7 +444,7 @@ packages:
     description:
       name: pub_semver
       sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.2.0"
   record_use:
@@ -452,7 +452,7 @@ packages:
     description:
       name: record_use
       sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.6.0"
   rxdart:
@@ -460,7 +460,7 @@ packages:
     description:
       name: rxdart
       sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.28.0"
   sky_engine:
@@ -473,55 +473,55 @@ packages:
     description:
       name: source_span
       sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.10.2"
   sqflite:
     dependency: transitive
     description:
       name: sqflite
-      sha256: "564cfed0746fe53140c23b70b308e045c3b31f17778f2f326ccb7d804ea0250a"
-      url: "https://pub.dev"
+      sha256: "58a799e6ac17dd32fbab93813d39ed835a75ccc0f8f85b8955fe318c6712b082"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.4.2+1"
+    version: "2.4.3"
   sqflite_android:
     dependency: transitive
     description:
       name: sqflite_android
-      sha256: "881e28efdcc9950fd8e9bb42713dcf1103e62a2e7168f23c9338d82db13dec40"
-      url: "https://pub.dev"
+      sha256: d0548f9d7422a2dae99ec6f8b0a3074463b132d216fa5ba0d230eeefc901983b
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.4.2+3"
+    version: "2.4.3"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "1581ffbf7a0e333b380d6a30737d78516b826cb35beb7fb0bf8a3ea0c678b465"
-      url: "https://pub.dev"
+      sha256: "5bf6a55c166e73bf651ba7ec3ed486e577620e3dc8f3a9c6a258a8031b624590"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.5.8"
+    version: "2.5.11"
   sqflite_darwin:
     dependency: transitive
     description:
       name: sqflite_darwin
-      sha256: "279832e5cde3fe99e8571879498c9211f3ca6391b0d818df4e17d9fff5c6ccb3"
-      url: "https://pub.dev"
+      sha256: c86ca18b8f666bbf903924687fe21cc16fc385d086005067e26619ca530bef9f
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3+1"
   sqflite_platform_interface:
     dependency: transitive
     description:
       name: sqflite_platform_interface
-      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
-      url: "https://pub.dev"
+      sha256: f84939f84350d92d04416f8bc4dc52d3896aec7716cc9e80cf0146342139dc50
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.12.1"
   stream_channel:
@@ -529,7 +529,7 @@ packages:
     description:
       name: stream_channel
       sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.4"
   string_scanner:
@@ -537,39 +537,39 @@ packages:
     description:
       name: string_scanner
       sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.4.1"
   synchronized:
     dependency: transitive
     description:
       name: synchronized
-      sha256: c254ade258ec8282947a0acbbc90b9575b4f19673533ee46f2f6e9b3aeefd7c0
-      url: "https://pub.dev"
+      sha256: "93b153dcb6a26dcddee6ca087dd634b53e38c10b5aa163e8e49501a776456153"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.4.0"
+    version: "3.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
-      url: "https://pub.dev"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   tuple:
     dependency: transitive
     description:
       name: tuple
       sha256: a97ce2013f240b2f3807bcbaf218765b6f301c3eff91092bcfa23a039e7dd151
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.0.2"
   typed_data:
@@ -577,23 +577,23 @@ packages:
     description:
       name: typed_data
       sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.4.0"
   uuid:
     dependency: transitive
     description:
       name: uuid
-      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
-      url: "https://pub.dev"
+      sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "4.5.3"
+    version: "4.6.0"
   vector_graphics:
     dependency: transitive
     description:
       name: vector_graphics
       sha256: "2306c03da2ba81724afeb589c351ebbc0aa7d86005925be8f8735856dbe5e42d"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.2.2"
   vector_graphics_codec:
@@ -601,23 +601,23 @@ packages:
     description:
       name: vector_graphics_codec
       sha256: "99fd9fbd34d9f9a32efd7b6a6aae14125d8237b10403b422a6a6dfeac2806146"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.1.13"
   vector_graphics_compiler:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "7ee12e6dffe0fc8e755179d6d91b3b34f5924223fc104d85572ef9180d73d172"
-      url: "https://pub.dev"
+      sha256: "142a9146f447d15b10bdc00e21d5f4d83e5b32bb5f8f8f5a04c75311344923a3"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.2.5"
+    version: "1.2.6"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.2.0"
   vm_service:
@@ -625,7 +625,7 @@ packages:
     description:
       name: vm_service
       sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "15.2.0"
   web:
@@ -633,7 +633,7 @@ packages:
     description:
       name: web
       sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.1.1"
   xdg_directories:
@@ -641,25 +641,25 @@ packages:
     description:
       name: xdg_directories
       sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.1.0"
   xml:
     dependency: transitive
     description:
       name: xml
-      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
-      url: "https://pub.dev"
+      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "6.6.1"
+    version: "7.0.1"
   yaml:
     dependency: transitive
     description:
       name: yaml
       sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.3 <4.0.0"
-  flutter: ">=3.38.4"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_smooth_markdown/flutter_smooth_markdown.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:flutter_smooth_markdown_example/editor_preview_main.dart';
+import 'package:flutter_smooth_markdown_example/html_demo.dart';
 import 'package:flutter_smooth_markdown_example/main.dart';
 
 void main() {
@@ -39,4 +40,31 @@ void main() {
     expect(find.text('Scratch-style editor preview'), findsOneWidget);
     expect(find.byType(SmoothMarkdownEditor), findsOneWidget);
   });
+
+  // Guards the three HTML-rendering regression fixes (streaming tag
+  // withholding, image src policy split, non-breaking BlockRenderer typedef)
+  // by ensuring the HtmlDemo content — which now includes the new image-src
+  // policy, streaming-withholding, and API-note sections — parses and
+  // renders under the default (HTML enabled) config without throwing.
+  //
+  // Uses a fixed-frame pump rather than pumpAndSettle because the demo
+  // references a live network image, which never settles under the widget
+  // test binding's stubbed HttpClient. The demo content is long and most of
+  // it scrolls out of the viewport, so we assert on the first (always-built)
+  // header plus the lead paragraph text to confirm a successful render; the
+  // rejected-image alt-text behavior is covered directly by
+  // `test/parser/html_utils_test.dart`.
+  testWidgets(
+    'HtmlDemo renders without throwing under default HTML config',
+    (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: HtmlDemo()));
+      for (var i = 0; i < 5; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+
+      // The document title is always in the first viewport, so it proves the
+      // markdown tree built without an exception during parsing/rendering.
+      expect(find.text('HTML Tags Demo'), findsOneWidget);
+    },
+  );
 }

--- a/lib/flutter_smooth_markdown.dart
+++ b/lib/flutter_smooth_markdown.dart
@@ -45,6 +45,8 @@ export 'src/renderer/builders/enhanced_blockquote_builder.dart';
 export 'src/renderer/builders/enhanced_code_block_builder.dart';
 export 'src/renderer/builders/enhanced_header_builder.dart';
 export 'src/renderer/builders/enhanced_link_builder.dart';
+export 'src/renderer/builders/html_block_builder.dart';
+export 'src/renderer/builders/html_inline_builder.dart';
 export 'src/renderer/builders/inline_math_builder.dart';
 export 'src/renderer/builders/mermaid_builder.dart';
 export 'src/renderer/builders/thinking_builder.dart';

--- a/lib/flutter_smooth_markdown.dart
+++ b/lib/flutter_smooth_markdown.dart
@@ -17,6 +17,7 @@ export 'src/editor/wikilink.dart';
 export 'src/mermaid/mermaid.dart';
 
 // Export AST nodes
+export 'src/parser/ast/html_nodes.dart';
 export 'src/parser/ast/markdown_node.dart';
 
 // Export parser

--- a/lib/src/config/markdown_config.dart
+++ b/lib/src/config/markdown_config.dart
@@ -41,8 +41,18 @@ import 'package:flutter/widgets.dart';
 /// ## Security Considerations
 ///
 /// **HTML Support**: By default, HTML tags are disabled ([enableHtml] = false)
-/// for security reasons. When enabled, HTML is sanitized to prevent XSS attacks,
-/// but it's recommended to only enable this for trusted content.
+/// for security reasons. When enabled, only a whitelist of tags is rendered:
+///
+/// - Inline: `b/strong`, `i/em`, `u/ins`, `s/del/strike`, `mark`, `sub`,
+///   `sup`, `kbd`, `code`, `br`, `a`, `img`, `font`, `span`
+/// - Block: `div`, `p`, `center`, `blockquote`, `hr` (plus the existing
+///   `details`/`summary` support)
+///
+/// Unknown tags are stripped while their content is kept. Link and image
+/// URLs are restricted to http, https, mailto, tel, and relative paths —
+/// `javascript:`, `data:`, and other schemes are rejected. Styling via
+/// `font`/`span` is limited to color, background color, and font size.
+/// It's still recommended to only enable this for trusted content.
 ///
 /// ```dart
 /// // Only enable for trusted content
@@ -145,10 +155,14 @@ class MarkdownConfig {
     this.imagePlaceholderBuilder,
   });
 
-  /// Whether to allow inline HTML tags
+  /// Whether to allow whitelisted HTML tags
   ///
-  /// For security reasons, this is disabled by default.
-  /// When enabled, HTML will be sanitized to prevent XSS attacks.
+  /// For security reasons, this is disabled by default. When enabled,
+  /// a safe whitelist of inline tags (`b`, `i`, `u`, `s`, `mark`,
+  /// `sub`, `sup`, `kbd`, `code`, `br`, `a`, `img`, `font`, `span`)
+  /// and block tags (`div`, `p`, `center`, `blockquote`, `hr`) is
+  /// rendered. Unknown tags are stripped keeping their content, and
+  /// unsafe URL schemes such as `javascript:` are rejected.
   final bool enableHtml;
 
   /// Whether to enable syntax highlighting for code blocks
@@ -189,7 +203,8 @@ class MarkdownConfig {
   final String syntaxHighlightTheme;
 
   /// Custom error widget builder for failed image loads
-  final Widget Function(BuildContext context, Object error, StackTrace? stackTrace)?
+  final Widget Function(
+          BuildContext context, Object error, StackTrace? stackTrace)?
       imageErrorBuilder;
 
   /// Custom placeholder widget builder for loading images

--- a/lib/src/config/style_sheet.dart
+++ b/lib/src/config/style_sheet.dart
@@ -85,6 +85,11 @@ import 'package:flutter/material.dart';
 ///
 /// - [SmoothMarkdown], which uses this stylesheet for rendering
 /// - [MarkdownConfig], for configuring parsing behavior
+
+/// Font scale applied to subscript and superscript text, relative to the
+/// surrounding text size.
+const double markdownSubSupFontScale = 0.75;
+
 class MarkdownStyleSheet {
   /// Creates a custom Markdown style sheet.
   ///
@@ -249,10 +254,10 @@ class MarkdownStyleSheet {
         color: Colors.black87,
       ),
       subscriptStyle: base.copyWith(
-        fontSize: (base.fontSize ?? 16) * 0.75,
+        fontSize: (base.fontSize ?? 16) * markdownSubSupFontScale,
       ),
       superscriptStyle: base.copyWith(
-        fontSize: (base.fontSize ?? 16) * 0.75,
+        fontSize: (base.fontSize ?? 16) * markdownSubSupFontScale,
       ),
       listBulletStyle: base,
       tableHeaderStyle: base.copyWith(fontWeight: FontWeight.bold),
@@ -597,10 +602,10 @@ class MarkdownStyleSheet {
         fontSize: 13,
       ),
       subscriptStyle: base.copyWith(
-        fontSize: (base.fontSize ?? 16) * 0.75,
+        fontSize: (base.fontSize ?? 16) * markdownSubSupFontScale,
       ),
       superscriptStyle: base.copyWith(
-        fontSize: (base.fontSize ?? 16) * 0.75,
+        fontSize: (base.fontSize ?? 16) * markdownSubSupFontScale,
       ),
       listBulletStyle: base,
       tableHeaderStyle: base.copyWith(

--- a/lib/src/config/style_sheet.dart
+++ b/lib/src/config/style_sheet.dart
@@ -121,6 +121,11 @@ class MarkdownStyleSheet {
     this.boldStyle,
     this.italicStyle,
     this.strikethroughStyle,
+    this.underlineStyle,
+    this.highlightStyle,
+    this.kbdStyle,
+    this.subscriptStyle,
+    this.superscriptStyle,
     this.listBulletStyle,
     this.tableHeaderStyle,
     this.tableCellStyle,
@@ -230,6 +235,24 @@ class MarkdownStyleSheet {
       italicStyle: base.copyWith(fontStyle: FontStyle.italic),
       strikethroughStyle: base.copyWith(
         decoration: TextDecoration.lineThrough,
+      ),
+      underlineStyle: base.copyWith(
+        decoration: TextDecoration.underline,
+      ),
+      highlightStyle: base.copyWith(
+        backgroundColor: const Color(0xFFFFF176),
+        color: Colors.black87,
+      ),
+      kbdStyle: base.copyWith(
+        fontFamily: 'monospace',
+        fontSize: 13,
+        color: Colors.black87,
+      ),
+      subscriptStyle: base.copyWith(
+        fontSize: (base.fontSize ?? 16) * 0.75,
+      ),
+      superscriptStyle: base.copyWith(
+        fontSize: (base.fontSize ?? 16) * 0.75,
       ),
       listBulletStyle: base,
       tableHeaderStyle: base.copyWith(fontWeight: FontWeight.bold),
@@ -361,7 +384,8 @@ class MarkdownStyleSheet {
   ///
   /// Perfect for documentation apps, README viewers, or any app that wants
   /// to match GitHub's familiar markdown aesthetic.
-  factory MarkdownStyleSheet.github({Brightness brightness = Brightness.light}) {
+  factory MarkdownStyleSheet.github(
+      {Brightness brightness = Brightness.light}) {
     if (brightness == Brightness.dark) {
       return MarkdownStyleSheet.dark().copyWith(
         textStyle: const TextStyle(fontSize: 16, color: Color(0xFFE6EDF3)),
@@ -422,7 +446,8 @@ class MarkdownStyleSheet {
   /// ```
   ///
   /// Ideal for code-focused apps, developer tools, or editor-style interfaces.
-  factory MarkdownStyleSheet.vscode({Brightness brightness = Brightness.light}) {
+  factory MarkdownStyleSheet.vscode(
+      {Brightness brightness = Brightness.light}) {
     if (brightness == Brightness.dark) {
       return MarkdownStyleSheet.dark().copyWith(
         textStyle: const TextStyle(fontSize: 16, color: Color(0xFFCCCCCC)),
@@ -561,6 +586,22 @@ class MarkdownStyleSheet {
       strikethroughStyle: base.copyWith(
         decoration: TextDecoration.lineThrough,
       ),
+      underlineStyle: base.copyWith(
+        decoration: TextDecoration.underline,
+      ),
+      highlightStyle: base.copyWith(
+        backgroundColor: const Color(0xFF4D4400),
+      ),
+      kbdStyle: base.copyWith(
+        fontFamily: 'monospace',
+        fontSize: 13,
+      ),
+      subscriptStyle: base.copyWith(
+        fontSize: (base.fontSize ?? 16) * 0.75,
+      ),
+      superscriptStyle: base.copyWith(
+        fontSize: (base.fontSize ?? 16) * 0.75,
+      ),
       listBulletStyle: base,
       tableHeaderStyle: base.copyWith(
         fontWeight: FontWeight.bold,
@@ -652,6 +693,21 @@ class MarkdownStyleSheet {
   /// Strikethrough text style
   final TextStyle? strikethroughStyle;
 
+  /// Style for underlined text from HTML `<u>`/`<ins>` tags
+  final TextStyle? underlineStyle;
+
+  /// Style for highlighted text from the HTML `<mark>` tag
+  final TextStyle? highlightStyle;
+
+  /// Style for keyboard input from the HTML `<kbd>` tag
+  final TextStyle? kbdStyle;
+
+  /// Style for subscript text from the HTML `<sub>` tag
+  final TextStyle? subscriptStyle;
+
+  /// Style for superscript text from the HTML `<sup>` tag
+  final TextStyle? superscriptStyle;
+
   /// List bullet style
   final TextStyle? listBulletStyle;
 
@@ -717,6 +773,11 @@ class MarkdownStyleSheet {
     TextStyle? boldStyle,
     TextStyle? italicStyle,
     TextStyle? strikethroughStyle,
+    TextStyle? underlineStyle,
+    TextStyle? highlightStyle,
+    TextStyle? kbdStyle,
+    TextStyle? subscriptStyle,
+    TextStyle? superscriptStyle,
     TextStyle? listBulletStyle,
     TextStyle? tableHeaderStyle,
     TextStyle? tableCellStyle,
@@ -750,15 +811,23 @@ class MarkdownStyleSheet {
       boldStyle: boldStyle ?? this.boldStyle,
       italicStyle: italicStyle ?? this.italicStyle,
       strikethroughStyle: strikethroughStyle ?? this.strikethroughStyle,
+      underlineStyle: underlineStyle ?? this.underlineStyle,
+      highlightStyle: highlightStyle ?? this.highlightStyle,
+      kbdStyle: kbdStyle ?? this.kbdStyle,
+      subscriptStyle: subscriptStyle ?? this.subscriptStyle,
+      superscriptStyle: superscriptStyle ?? this.superscriptStyle,
       listBulletStyle: listBulletStyle ?? this.listBulletStyle,
       tableHeaderStyle: tableHeaderStyle ?? this.tableHeaderStyle,
       tableCellStyle: tableCellStyle ?? this.tableCellStyle,
       blockquoteDecoration: blockquoteDecoration ?? this.blockquoteDecoration,
       codeBlockDecoration: codeBlockDecoration ?? this.codeBlockDecoration,
       tableBorder: tableBorder ?? this.tableBorder,
-      tableHeaderDecoration: tableHeaderDecoration ?? this.tableHeaderDecoration,
-      tableOddRowDecoration: tableOddRowDecoration ?? this.tableOddRowDecoration,
-      tableEvenRowDecoration: tableEvenRowDecoration ?? this.tableEvenRowDecoration,
+      tableHeaderDecoration:
+          tableHeaderDecoration ?? this.tableHeaderDecoration,
+      tableOddRowDecoration:
+          tableOddRowDecoration ?? this.tableOddRowDecoration,
+      tableEvenRowDecoration:
+          tableEvenRowDecoration ?? this.tableEvenRowDecoration,
       horizontalRuleColor: horizontalRuleColor ?? this.horizontalRuleColor,
       horizontalRuleThickness:
           horizontalRuleThickness ?? this.horizontalRuleThickness,

--- a/lib/src/parser/ast/html_nodes.dart
+++ b/lib/src/parser/ast/html_nodes.dart
@@ -1,0 +1,255 @@
+import 'markdown_node.dart';
+
+/// Horizontal alignment for HTML block elements
+///
+/// Parsed from the `align` attribute of HTML block tags such as
+/// `<div align="center">` or implied by the tag itself (`<center>`).
+enum HtmlBlockAlignment {
+  /// Left-aligned content
+  left,
+
+  /// Center-aligned content
+  center,
+
+  /// Right-aligned content
+  right,
+}
+
+/// Represents underlined text from HTML `<u>` or `<ins>` tags
+class UnderlineNode extends MarkdownNode {
+  /// Creates a new underline node
+  const UnderlineNode(this.children);
+
+  /// The child nodes
+  final List<MarkdownNode> children;
+
+  @override
+  String get type => 'underline';
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'type': type,
+        'children': children.map((child) => child.toJson()).toList(),
+      };
+
+  @override
+  UnderlineNode copyWith({List<MarkdownNode>? children}) {
+    return UnderlineNode(children ?? this.children);
+  }
+
+  @override
+  String toString() => 'UnderlineNode(children: ${children.length})';
+}
+
+/// Represents highlighted text from the HTML `<mark>` tag
+class HighlightNode extends MarkdownNode {
+  /// Creates a new highlight node
+  const HighlightNode(this.children);
+
+  /// The child nodes
+  final List<MarkdownNode> children;
+
+  @override
+  String get type => 'highlight';
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'type': type,
+        'children': children.map((child) => child.toJson()).toList(),
+      };
+
+  @override
+  HighlightNode copyWith({List<MarkdownNode>? children}) {
+    return HighlightNode(children ?? this.children);
+  }
+
+  @override
+  String toString() => 'HighlightNode(children: ${children.length})';
+}
+
+/// Represents subscript text from the HTML `<sub>` tag
+class SubscriptNode extends MarkdownNode {
+  /// Creates a new subscript node
+  const SubscriptNode(this.children);
+
+  /// The child nodes
+  final List<MarkdownNode> children;
+
+  @override
+  String get type => 'subscript';
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'type': type,
+        'children': children.map((child) => child.toJson()).toList(),
+      };
+
+  @override
+  SubscriptNode copyWith({List<MarkdownNode>? children}) {
+    return SubscriptNode(children ?? this.children);
+  }
+
+  @override
+  String toString() => 'SubscriptNode(children: ${children.length})';
+}
+
+/// Represents superscript text from the HTML `<sup>` tag
+class SuperscriptNode extends MarkdownNode {
+  /// Creates a new superscript node
+  const SuperscriptNode(this.children);
+
+  /// The child nodes
+  final List<MarkdownNode> children;
+
+  @override
+  String get type => 'superscript';
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'type': type,
+        'children': children.map((child) => child.toJson()).toList(),
+      };
+
+  @override
+  SuperscriptNode copyWith({List<MarkdownNode>? children}) {
+    return SuperscriptNode(children ?? this.children);
+  }
+
+  @override
+  String toString() => 'SuperscriptNode(children: ${children.length})';
+}
+
+/// Represents keyboard input from the HTML `<kbd>` tag
+class KbdNode extends MarkdownNode {
+  /// Creates a new keyboard input node
+  const KbdNode(this.children);
+
+  /// The child nodes
+  final List<MarkdownNode> children;
+
+  @override
+  String get type => 'kbd';
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'type': type,
+        'children': children.map((child) => child.toJson()).toList(),
+      };
+
+  @override
+  KbdNode copyWith({List<MarkdownNode>? children}) {
+    return KbdNode(children ?? this.children);
+  }
+
+  @override
+  String toString() => 'KbdNode(children: ${children.length})';
+}
+
+/// Represents styled inline text from HTML `<font>` or `<span style>` tags
+///
+/// Only a safe subset of styling is supported: text color, background
+/// color, and font size. Colors are stored as ARGB integers so the AST
+/// stays free of Flutter imports.
+class StyledSpanNode extends MarkdownNode {
+  /// Creates a new styled span node
+  const StyledSpanNode({
+    required this.children,
+    this.color,
+    this.backgroundColor,
+    this.fontSize,
+  });
+
+  /// The child nodes
+  final List<MarkdownNode> children;
+
+  /// The text color as an ARGB integer, if specified
+  final int? color;
+
+  /// The background color as an ARGB integer, if specified
+  final int? backgroundColor;
+
+  /// The font size in logical pixels, if specified
+  final double? fontSize;
+
+  @override
+  String get type => 'styled_span';
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'type': type,
+        'children': children.map((child) => child.toJson()).toList(),
+        if (color != null) 'color': color,
+        if (backgroundColor != null) 'backgroundColor': backgroundColor,
+        if (fontSize != null) 'fontSize': fontSize,
+      };
+
+  @override
+  StyledSpanNode copyWith({
+    List<MarkdownNode>? children,
+    int? color,
+    int? backgroundColor,
+    double? fontSize,
+  }) {
+    return StyledSpanNode(
+      children: children ?? this.children,
+      color: color ?? this.color,
+      backgroundColor: backgroundColor ?? this.backgroundColor,
+      fontSize: fontSize ?? this.fontSize,
+    );
+  }
+
+  @override
+  String toString() => 'StyledSpanNode(children: ${children.length}, '
+      'color: $color, backgroundColor: $backgroundColor, '
+      'fontSize: $fontSize)';
+}
+
+/// Represents an HTML block element (`<div>`, `<p>`, or `<center>`)
+///
+/// Block children are parsed as regular markdown, so HTML blocks can
+/// contain headers, lists, code blocks, and other block-level content.
+class HtmlBlockNode extends MarkdownNode {
+  /// Creates a new HTML block node
+  const HtmlBlockNode({
+    required this.tag,
+    required this.children,
+    this.align,
+  });
+
+  /// The lowercased HTML tag name (`div`, `p`, or `center`)
+  final String tag;
+
+  /// The block-level child nodes
+  final List<MarkdownNode> children;
+
+  /// Optional horizontal alignment from the `align` attribute
+  final HtmlBlockAlignment? align;
+
+  @override
+  String get type => 'html_block';
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'type': type,
+        'tag': tag,
+        'children': children.map((child) => child.toJson()).toList(),
+        if (align != null) 'align': align!.name,
+      };
+
+  @override
+  HtmlBlockNode copyWith({
+    String? tag,
+    List<MarkdownNode>? children,
+    HtmlBlockAlignment? align,
+  }) {
+    return HtmlBlockNode(
+      tag: tag ?? this.tag,
+      children: children ?? this.children,
+      align: align ?? this.align,
+    );
+  }
+
+  @override
+  String toString() => 'HtmlBlockNode(tag: $tag, '
+      'children: ${children.length}, align: $align)';
+}

--- a/lib/src/parser/ast/markdown_node.dart
+++ b/lib/src/parser/ast/markdown_node.dart
@@ -479,6 +479,8 @@ class ImageNode extends MarkdownNode {
     required this.url,
     required this.alt,
     this.title,
+    this.width,
+    this.height,
   });
 
   /// The image URL
@@ -490,6 +492,16 @@ class ImageNode extends MarkdownNode {
   /// Optional title attribute
   final String? title;
 
+  /// Optional display width in logical pixels
+  ///
+  /// Set when the image originates from an HTML `<img width="...">` tag.
+  final double? width;
+
+  /// Optional display height in logical pixels
+  ///
+  /// Set when the image originates from an HTML `<img height="...">` tag.
+  final double? height;
+
   @override
   String get type => 'image';
 
@@ -499,14 +511,24 @@ class ImageNode extends MarkdownNode {
         'url': url,
         'alt': alt,
         if (title != null) 'title': title,
+        if (width != null) 'width': width,
+        if (height != null) 'height': height,
       };
 
   @override
-  ImageNode copyWith({String? url, String? alt, String? title}) {
+  ImageNode copyWith({
+    String? url,
+    String? alt,
+    String? title,
+    double? width,
+    double? height,
+  }) {
     return ImageNode(
       url: url ?? this.url,
       alt: alt ?? this.alt,
       title: title ?? this.title,
+      width: width ?? this.width,
+      height: height ?? this.height,
     );
   }
 

--- a/lib/src/parser/block_parser.dart
+++ b/lib/src/parser/block_parser.dart
@@ -1,4 +1,6 @@
+import 'ast/html_nodes.dart';
 import 'ast/markdown_node.dart';
+import 'html/html_utils.dart';
 import 'inline_parser.dart';
 import 'parser_plugin.dart';
 
@@ -12,21 +14,29 @@ import 'parser_plugin.dart';
 /// - Code blocks
 /// - Horizontal rules
 /// - Tables
+/// - Whitelisted HTML blocks (when [BlockParser.new] `enableHtml` is set)
 ///
 /// Supports custom block plugins through [ParserPluginRegistry].
 class BlockParser {
   /// Creates a new block parser
   ///
   /// Optionally accepts a [ParserPluginRegistry] for custom block plugins.
-  BlockParser({ParserPluginRegistry? plugins})
+  /// When [enableHtml] is true, whitelisted HTML blocks (`<div>`, `<p>`,
+  /// `<center>`, `<blockquote>`, standalone `<hr>`) and inline HTML in
+  /// nested content are parsed.
+  BlockParser({ParserPluginRegistry? plugins, bool enableHtml = false})
       : _plugins = plugins,
-        _inlineParser = InlineParser(plugins: plugins);
+        _enableHtml = enableHtml,
+        _inlineParser = InlineParser(plugins: plugins, enableHtml: enableHtml);
 
   /// The inline parser for parsing cell contents
   final InlineParser _inlineParser;
 
   /// Plugin registry for custom block parsers
   final ParserPluginRegistry? _plugins;
+
+  /// Whether whitelisted HTML blocks are parsed
+  final bool _enableHtml;
 
   // Pre-compiled RegExp patterns to avoid recompilation on every call
   static final _hrDashPattern = RegExp(r'^-{3,}$');
@@ -40,6 +50,9 @@ class BlockParser {
   static final _footnotePattern = RegExp(r'^\[\^[^\]]+\]:\s+.+');
   static final _footnoteCapturePattern = RegExp(r'^\[\^([^\]]+)\]:\s+(.+)$');
   static final _tableSeparatorPattern = RegExp(r'^\s*:?-+:?\s*$');
+  static final _htmlBlockStartPattern =
+      RegExp(r'^<(?:div|p|center|blockquote)\b', caseSensitive: false);
+  static final _htmlHrPattern = RegExp(r'^<hr\s*/?>$', caseSensitive: false);
 
   /// Parses a markdown text into a list of block-level nodes
   List<MarkdownNode> parse(String markdown) {
@@ -116,6 +129,17 @@ class BlockParser {
       // Try details block
       if (node == null && _isDetailsStart(line)) {
         final result = _parseDetails(lines, i);
+        node = result.node;
+        consumed = result.linesConsumed;
+      }
+      // Try standalone HTML hr line
+      if (node == null && _isHtmlHrLine(line)) {
+        node = const HorizontalRuleNode();
+        consumed = 1;
+      }
+      // Try HTML block
+      if (node == null && _isHtmlBlockStart(line)) {
+        final result = _parseHtmlBlock(lines, i);
         node = result.node;
         consumed = result.linesConsumed;
       }
@@ -677,7 +701,9 @@ class BlockParser {
           _isListItem(line) ||
           _isHorizontalRule(line) ||
           _isFootnoteDefinition(line) ||
-          _isTableStart(lines, i)) {
+          _isTableStart(lines, i) ||
+          _isHtmlHrLine(line) ||
+          _isHtmlBlockStart(line)) {
         break;
       }
 
@@ -872,6 +898,156 @@ class BlockParser {
     return trimmed == '<details>' || trimmed == '<details open>';
   }
 
+  /// Checks if a line is a standalone HTML `<hr>` tag
+  bool _isHtmlHrLine(String line) {
+    if (!_enableHtml) return false;
+    return _htmlHrPattern.hasMatch(line.trim());
+  }
+
+  /// Checks if a line starts a whitelisted HTML block
+  ///
+  /// A line starts an HTML block only when it begins with an opening
+  /// `<div>`, `<p>`, `<center>`, or `<blockquote>` tag. Mid-line tags
+  /// stay part of the surrounding paragraph and are handled by the
+  /// inline parser instead.
+  bool _isHtmlBlockStart(String line) {
+    if (!_enableHtml) return false;
+    final trimmed = line.trim();
+    if (!_htmlBlockStartPattern.hasMatch(trimmed)) return false;
+    final tag = lexHtmlTag(trimmed, 0);
+    return tag != null && !tag.isClosing && htmlBlockTags.contains(tag.name);
+  }
+
+  /// Parses a whitelisted HTML block
+  ///
+  /// The block ends on the line where the matching close tag (tracked
+  /// with a same-name nesting counter) brings nesting to zero. Text
+  /// after that terminating close tag on the same line is kept as
+  /// trailing content so nothing is silently dropped. A missing close
+  /// tag consumes all remaining lines, which keeps incremental
+  /// (streaming) re-parses stable.
+  _ParseResult _parseHtmlBlock(List<String> lines, int startIndex) {
+    final firstLine = lines[startIndex].trim();
+    final openTag = lexHtmlTag(firstLine, 0);
+    if (openTag == null) {
+      throw FormatException('Invalid HTML block: ${lines[startIndex]}');
+    }
+    final tagName = openTag.name;
+    final align = _parseHtmlBlockAlignment(openTag);
+
+    if (openTag.isSelfClosing) {
+      return _ParseResult(
+        node: _buildHtmlBlockNode(tagName, const [], align),
+        linesConsumed: 1,
+      );
+    }
+
+    final contentLines = <String>[];
+    var nesting = 1;
+    var lineIndex = startIndex;
+
+    while (lineIndex < lines.length) {
+      final isFirst = lineIndex == startIndex;
+      final lineText = isFirst ? firstLine : lines[lineIndex];
+      final from = isFirst ? openTag.end : 0;
+      final scan = _scanHtmlBlockLine(lineText, from, tagName, nesting);
+      nesting = scan.nesting;
+
+      if (scan.closeStart != null) {
+        // Terminating close tag found on this line.
+        final before = lineText.substring(from, scan.closeStart);
+        final after = lineText.substring(scan.closeEnd!);
+        if (before.trim().isNotEmpty) contentLines.add(before);
+        if (after.trim().isNotEmpty) contentLines.add(after);
+        lineIndex++;
+        break;
+      }
+
+      final content = lineText.substring(from);
+      if (!isFirst || content.trim().isNotEmpty) {
+        contentLines.add(content);
+      }
+      lineIndex++;
+    }
+
+    final source = contentLines.join('\n');
+    final children = source.trim().isEmpty ? <MarkdownNode>[] : parse(source);
+
+    return _ParseResult(
+      node: _buildHtmlBlockNode(tagName, children, align),
+      linesConsumed: lineIndex - startIndex,
+    );
+  }
+
+  /// Scans one line of an HTML block, tracking same-name nesting.
+  ///
+  /// Returns the updated nesting count and, when nesting reaches zero
+  /// on this line, the location of the terminating close tag.
+  _HtmlLineScan _scanHtmlBlockLine(
+    String line,
+    int from,
+    String name,
+    int nesting,
+  ) {
+    var currentNesting = nesting;
+    var i = from;
+    while (i < line.length) {
+      if (line[i] != '<') {
+        i++;
+        continue;
+      }
+      final tag = lexHtmlTag(line, i);
+      if (tag == null) {
+        i++;
+        continue;
+      }
+      if (tag.name == name) {
+        if (tag.isClosing) {
+          currentNesting--;
+          if (currentNesting == 0) {
+            return _HtmlLineScan(
+              nesting: 0,
+              closeStart: i,
+              closeEnd: tag.end,
+            );
+          }
+        } else if (!tag.isSelfClosing) {
+          currentNesting++;
+        }
+      }
+      i = tag.end;
+    }
+    return _HtmlLineScan(nesting: currentNesting);
+  }
+
+  /// Reads the alignment of an HTML block from its open tag.
+  HtmlBlockAlignment? _parseHtmlBlockAlignment(HtmlTag tag) {
+    if (tag.name == 'center') return HtmlBlockAlignment.center;
+    switch (tag.attributes['align']?.toLowerCase()) {
+      case 'left':
+        return HtmlBlockAlignment.left;
+      case 'center':
+        return HtmlBlockAlignment.center;
+      case 'right':
+        return HtmlBlockAlignment.right;
+      default:
+        return null;
+    }
+  }
+
+  /// Builds the AST node for a parsed HTML block.
+  ///
+  /// `<blockquote>` reuses the markdown [BlockquoteNode] so it renders
+  /// through the existing blockquote builder.
+  MarkdownNode _buildHtmlBlockNode(
+    String tag,
+    List<MarkdownNode> children,
+    HtmlBlockAlignment? align,
+  ) {
+    if (tag == 'blockquote') return BlockquoteNode(children);
+    return HtmlBlockNode(tag: tag, children: children, align: align);
+  }
+
   /// Parses a details block
   ///
   /// Format:
@@ -1020,4 +1196,22 @@ class _CodeFence {
   final String marker;
   final String literal;
   final String info;
+}
+
+/// Result of scanning one line of an HTML block
+class _HtmlLineScan {
+  const _HtmlLineScan({
+    required this.nesting,
+    this.closeStart,
+    this.closeEnd,
+  });
+
+  /// Same-name nesting count after this line
+  final int nesting;
+
+  /// Index of the terminating close tag's `<`, if nesting reached zero
+  final int? closeStart;
+
+  /// Index just past the terminating close tag's `>`
+  final int? closeEnd;
 }

--- a/lib/src/parser/block_parser.dart
+++ b/lib/src/parser/block_parser.dart
@@ -900,7 +900,7 @@ class BlockParser {
 
   /// Checks if a line is a standalone HTML `<hr>` tag
   bool _isHtmlHrLine(String line) {
-    if (!_enableHtml) return false;
+    if (!_enableHtml || !_couldStartHtmlLine(line)) return false;
     return _htmlHrPattern.hasMatch(line.trim());
   }
 
@@ -914,10 +914,22 @@ class BlockParser {
   /// as an unterminated quote. Mid-line tags stay part of the
   /// surrounding paragraph and are handled by the inline parser instead.
   bool _isHtmlBlockStart(String line) {
-    if (!_enableHtml) return false;
+    if (!_enableHtml || !_couldStartHtmlLine(line)) return false;
     final trimmed = line.trim();
     if (!_htmlBlockStartPattern.hasMatch(trimmed)) return false;
     return lexHtmlTag(trimmed, 0) != null;
+  }
+
+  /// Cheap gate ahead of [String.trim] for HTML line detection.
+  ///
+  /// A block tag can only begin with `<` after leading whitespace, so a
+  /// line whose first character is neither `<` nor whitespace cannot
+  /// match. Skipping [String.trim] for the common case (plain paragraph
+  /// text) avoids a per-line string allocation on the parse hot path.
+  static bool _couldStartHtmlLine(String line) {
+    if (line.isEmpty) return false;
+    final first = line.codeUnitAt(0);
+    return first <= 0x20 || first == 0x3C; // whitespace or '<'
   }
 
   /// Parses a whitelisted HTML block
@@ -952,13 +964,19 @@ class BlockParser {
       final isFirst = lineIndex == startIndex;
       final lineText = isFirst ? firstLine : lines[lineIndex];
       final from = isFirst ? openTag.end : 0;
-      final scan = _scanHtmlBlockLine(lineText, from, tagName, nesting);
+      final scan = scanHtmlCloseTag(
+        lineText,
+        from,
+        tagName,
+        initialNesting: nesting,
+      );
       nesting = scan.nesting;
 
-      if (scan.closeStart != null) {
+      final close = scan.close;
+      if (close != null) {
         // Terminating close tag found on this line.
-        final before = lineText.substring(from, scan.closeStart);
-        final after = lineText.substring(scan.closeEnd!);
+        final before = lineText.substring(from, close.start);
+        final after = lineText.substring(close.end);
         if (before.trim().isNotEmpty) contentLines.add(before);
         if (after.trim().isNotEmpty) contentLines.add(after);
         lineIndex++;
@@ -979,48 +997,6 @@ class BlockParser {
       node: _buildHtmlBlockNode(tagName, children, align),
       linesConsumed: lineIndex - startIndex,
     );
-  }
-
-  /// Scans one line of an HTML block, tracking same-name nesting.
-  ///
-  /// Returns the updated nesting count and, when nesting reaches zero
-  /// on this line, the location of the terminating close tag.
-  _HtmlLineScan _scanHtmlBlockLine(
-    String line,
-    int from,
-    String name,
-    int nesting,
-  ) {
-    var currentNesting = nesting;
-    var i = from;
-    while (i < line.length) {
-      // 0x3C == '<'; codeUnitAt avoids per-character string allocation.
-      if (line.codeUnitAt(i) != 0x3C) {
-        i++;
-        continue;
-      }
-      final tag = lexHtmlTag(line, i);
-      if (tag == null) {
-        i++;
-        continue;
-      }
-      if (tag.name == name) {
-        if (tag.isClosing) {
-          currentNesting--;
-          if (currentNesting == 0) {
-            return _HtmlLineScan(
-              nesting: 0,
-              closeStart: i,
-              closeEnd: tag.end,
-            );
-          }
-        } else if (!tag.isSelfClosing) {
-          currentNesting++;
-        }
-      }
-      i = tag.end;
-    }
-    return _HtmlLineScan(nesting: currentNesting);
   }
 
   /// Reads the alignment of an HTML block from its open tag.
@@ -1199,22 +1175,4 @@ class _CodeFence {
   final String marker;
   final String literal;
   final String info;
-}
-
-/// Result of scanning one line of an HTML block
-class _HtmlLineScan {
-  const _HtmlLineScan({
-    required this.nesting,
-    this.closeStart,
-    this.closeEnd,
-  });
-
-  /// Same-name nesting count after this line
-  final int nesting;
-
-  /// Index of the terminating close tag's `<`, if nesting reached zero
-  final int? closeStart;
-
-  /// Index just past the terminating close tag's `>`
-  final int? closeEnd;
 }

--- a/lib/src/parser/block_parser.dart
+++ b/lib/src/parser/block_parser.dart
@@ -1,6 +1,5 @@
-import 'ast/html_nodes.dart';
 import 'ast/markdown_node.dart';
-import 'html/html_utils.dart';
+import 'html/html_block_parser.dart';
 import 'inline_parser.dart';
 import 'parser_plugin.dart';
 
@@ -26,8 +25,9 @@ class BlockParser {
   /// nested content are parsed.
   BlockParser({ParserPluginRegistry? plugins, bool enableHtml = false})
       : _plugins = plugins,
-        _enableHtml = enableHtml,
-        _inlineParser = InlineParser(plugins: plugins, enableHtml: enableHtml);
+        _inlineParser = InlineParser(plugins: plugins, enableHtml: enableHtml) {
+    _htmlParser = enableHtml ? HtmlBlockParser(parseChildren: parse) : null;
+  }
 
   /// The inline parser for parsing cell contents
   final InlineParser _inlineParser;
@@ -35,8 +35,7 @@ class BlockParser {
   /// Plugin registry for custom block parsers
   final ParserPluginRegistry? _plugins;
 
-  /// Whether whitelisted HTML blocks are parsed
-  final bool _enableHtml;
+  late final HtmlBlockParser? _htmlParser;
 
   // Pre-compiled RegExp patterns to avoid recompilation on every call
   static final _hrDashPattern = RegExp(r'^-{3,}$');
@@ -50,9 +49,6 @@ class BlockParser {
   static final _footnotePattern = RegExp(r'^\[\^[^\]]+\]:\s+.+');
   static final _footnoteCapturePattern = RegExp(r'^\[\^([^\]]+)\]:\s+(.+)$');
   static final _tableSeparatorPattern = RegExp(r'^\s*:?-+:?\s*$');
-  static final _htmlBlockStartPattern =
-      RegExp(r'^<(?:div|p|center|blockquote)\b', caseSensitive: false);
-  static final _htmlHrPattern = RegExp(r'^<hr\s*/?>$', caseSensitive: false);
 
   /// Parses a markdown text into a list of block-level nodes
   List<MarkdownNode> parse(String markdown) {
@@ -132,14 +128,13 @@ class BlockParser {
         node = result.node;
         consumed = result.linesConsumed;
       }
-      // Try standalone HTML hr line
-      if (node == null && _isHtmlHrLine(line)) {
+      final htmlMatch = node == null ? _htmlParser?.probe(line) : null;
+      if (node == null && htmlMatch is HtmlHorizontalRuleMatch) {
         node = const HorizontalRuleNode();
         consumed = 1;
       }
-      // Try HTML block
-      if (node == null && _isHtmlBlockStart(line)) {
-        final result = _parseHtmlBlock(lines, i);
+      if (node == null && htmlMatch is HtmlContainerBlockMatch) {
+        final result = _htmlParser!.parseBlock(lines, i, htmlMatch);
         node = result.node;
         consumed = result.linesConsumed;
       }
@@ -702,8 +697,7 @@ class BlockParser {
           _isHorizontalRule(line) ||
           _isFootnoteDefinition(line) ||
           _isTableStart(lines, i) ||
-          _isHtmlHrLine(line) ||
-          _isHtmlBlockStart(line)) {
+          _htmlParser?.probe(line) != null) {
         break;
       }
 
@@ -896,135 +890,6 @@ class BlockParser {
   bool _isDetailsStart(String line) {
     final trimmed = line.trim().toLowerCase();
     return trimmed == '<details>' || trimmed == '<details open>';
-  }
-
-  /// Checks if a line is a standalone HTML `<hr>` tag
-  bool _isHtmlHrLine(String line) {
-    if (!_enableHtml || !_couldStartHtmlLine(line)) return false;
-    return _htmlHrPattern.hasMatch(line.trim());
-  }
-
-  /// Checks if a line starts a whitelisted HTML block
-  ///
-  /// A line starts an HTML block only when it begins with an opening
-  /// `<div>`, `<p>`, `<center>`, or `<blockquote>` tag (the names are
-  /// fixed by [_htmlBlockStartPattern], so a successful regex match
-  /// already guarantees the tag name and that it is not a closing tag).
-  /// The follow-up [lexHtmlTag] call only rejects malformed tags such
-  /// as an unterminated quote. Mid-line tags stay part of the
-  /// surrounding paragraph and are handled by the inline parser instead.
-  bool _isHtmlBlockStart(String line) {
-    if (!_enableHtml || !_couldStartHtmlLine(line)) return false;
-    final trimmed = line.trim();
-    if (!_htmlBlockStartPattern.hasMatch(trimmed)) return false;
-    return lexHtmlTag(trimmed, 0) != null;
-  }
-
-  /// Cheap gate ahead of [String.trim] for HTML line detection.
-  ///
-  /// A block tag can only begin with `<` after leading whitespace, so a
-  /// line whose first character is neither `<` nor whitespace cannot
-  /// match. Skipping [String.trim] for the common case (plain paragraph
-  /// text) avoids a per-line string allocation on the parse hot path.
-  static bool _couldStartHtmlLine(String line) {
-    if (line.isEmpty) return false;
-    final first = line.codeUnitAt(0);
-    return first <= 0x20 || first == 0x3C; // whitespace or '<'
-  }
-
-  /// Parses a whitelisted HTML block
-  ///
-  /// The block ends on the line where the matching close tag (tracked
-  /// with a same-name nesting counter) brings nesting to zero. Text
-  /// after that terminating close tag on the same line is kept as
-  /// trailing content so nothing is silently dropped. A missing close
-  /// tag consumes all remaining lines, which keeps incremental
-  /// (streaming) re-parses stable.
-  _ParseResult _parseHtmlBlock(List<String> lines, int startIndex) {
-    final firstLine = lines[startIndex].trim();
-    final openTag = lexHtmlTag(firstLine, 0);
-    if (openTag == null) {
-      throw FormatException('Invalid HTML block: ${lines[startIndex]}');
-    }
-    final tagName = openTag.name;
-    final align = _parseHtmlBlockAlignment(openTag);
-
-    if (openTag.isSelfClosing) {
-      return _ParseResult(
-        node: _buildHtmlBlockNode(tagName, const [], align),
-        linesConsumed: 1,
-      );
-    }
-
-    final contentLines = <String>[];
-    var nesting = 1;
-    var lineIndex = startIndex;
-
-    while (lineIndex < lines.length) {
-      final isFirst = lineIndex == startIndex;
-      final lineText = isFirst ? firstLine : lines[lineIndex];
-      final from = isFirst ? openTag.end : 0;
-      final scan = scanHtmlCloseTag(
-        lineText,
-        from,
-        tagName,
-        initialNesting: nesting,
-      );
-      nesting = scan.nesting;
-
-      final close = scan.close;
-      if (close != null) {
-        // Terminating close tag found on this line.
-        final before = lineText.substring(from, close.start);
-        final after = lineText.substring(close.end);
-        if (before.trim().isNotEmpty) contentLines.add(before);
-        if (after.trim().isNotEmpty) contentLines.add(after);
-        lineIndex++;
-        break;
-      }
-
-      final content = lineText.substring(from);
-      if (!isFirst || content.trim().isNotEmpty) {
-        contentLines.add(content);
-      }
-      lineIndex++;
-    }
-
-    final source = contentLines.join('\n');
-    final children = source.trim().isEmpty ? <MarkdownNode>[] : parse(source);
-
-    return _ParseResult(
-      node: _buildHtmlBlockNode(tagName, children, align),
-      linesConsumed: lineIndex - startIndex,
-    );
-  }
-
-  /// Reads the alignment of an HTML block from its open tag.
-  HtmlBlockAlignment? _parseHtmlBlockAlignment(HtmlTag tag) {
-    if (tag.name == 'center') return HtmlBlockAlignment.center;
-    switch (tag.attributes['align']?.toLowerCase()) {
-      case 'left':
-        return HtmlBlockAlignment.left;
-      case 'center':
-        return HtmlBlockAlignment.center;
-      case 'right':
-        return HtmlBlockAlignment.right;
-      default:
-        return null;
-    }
-  }
-
-  /// Builds the AST node for a parsed HTML block.
-  ///
-  /// `<blockquote>` reuses the markdown [BlockquoteNode] so it renders
-  /// through the existing blockquote builder.
-  MarkdownNode _buildHtmlBlockNode(
-    String tag,
-    List<MarkdownNode> children,
-    HtmlBlockAlignment? align,
-  ) {
-    if (tag == 'blockquote') return BlockquoteNode(children);
-    return HtmlBlockNode(tag: tag, children: children, align: align);
   }
 
   /// Parses a details block

--- a/lib/src/parser/block_parser.dart
+++ b/lib/src/parser/block_parser.dart
@@ -992,7 +992,8 @@ class BlockParser {
     var currentNesting = nesting;
     var i = from;
     while (i < line.length) {
-      if (line[i] != '<') {
+      // 0x3C == '<'; codeUnitAt avoids per-character string allocation.
+      if (line.codeUnitAt(i) != 0x3C) {
         i++;
         continue;
       }

--- a/lib/src/parser/block_parser.dart
+++ b/lib/src/parser/block_parser.dart
@@ -907,15 +907,17 @@ class BlockParser {
   /// Checks if a line starts a whitelisted HTML block
   ///
   /// A line starts an HTML block only when it begins with an opening
-  /// `<div>`, `<p>`, `<center>`, or `<blockquote>` tag. Mid-line tags
-  /// stay part of the surrounding paragraph and are handled by the
-  /// inline parser instead.
+  /// `<div>`, `<p>`, `<center>`, or `<blockquote>` tag (the names are
+  /// fixed by [_htmlBlockStartPattern], so a successful regex match
+  /// already guarantees the tag name and that it is not a closing tag).
+  /// The follow-up [lexHtmlTag] call only rejects malformed tags such
+  /// as an unterminated quote. Mid-line tags stay part of the
+  /// surrounding paragraph and are handled by the inline parser instead.
   bool _isHtmlBlockStart(String line) {
     if (!_enableHtml) return false;
     final trimmed = line.trim();
     if (!_htmlBlockStartPattern.hasMatch(trimmed)) return false;
-    final tag = lexHtmlTag(trimmed, 0);
-    return tag != null && !tag.isClosing && htmlBlockTags.contains(tag.name);
+    return lexHtmlTag(trimmed, 0) != null;
   }
 
   /// Parses a whitelisted HTML block

--- a/lib/src/parser/html/html_block_parser.dart
+++ b/lib/src/parser/html/html_block_parser.dart
@@ -1,0 +1,161 @@
+import '../ast/html_nodes.dart';
+import '../ast/markdown_node.dart';
+import 'html_utils.dart';
+
+/// Parses nested block Markdown inside an HTML block.
+typedef HtmlBlockChildrenParser = List<MarkdownNode> Function(String source);
+
+/// A recognized HTML line that may interrupt normal paragraph parsing.
+sealed class HtmlBlockMatch {
+  const HtmlBlockMatch();
+}
+
+/// Match for a standalone HTML horizontal rule.
+final class HtmlHorizontalRuleMatch extends HtmlBlockMatch {
+  /// Creates a horizontal-rule match.
+  const HtmlHorizontalRuleMatch();
+}
+
+/// Match for a whitelisted container block.
+final class HtmlContainerBlockMatch extends HtmlBlockMatch {
+  /// Creates a match carrying the normalized line and lexed opening tag.
+  const HtmlContainerBlockMatch({
+    required this.firstLine,
+    required this.openTag,
+  });
+
+  /// Trimmed first source line used by block parsing.
+  final String firstLine;
+
+  /// Opening tag lexed during probing and reused during block parsing.
+  final HtmlTag openTag;
+}
+
+/// Result of parsing one HTML block.
+class HtmlBlockParseResult {
+  /// Creates a block HTML parse result.
+  const HtmlBlockParseResult({
+    required this.node,
+    required this.linesConsumed,
+  });
+
+  /// Existing Markdown AST node generated for the block.
+  final MarkdownNode node;
+
+  /// Number of source lines consumed.
+  final int linesConsumed;
+}
+
+/// Internal parser for whitelisted block HTML.
+class HtmlBlockParser {
+  /// Creates a parser that delegates nested Markdown to [parseChildren].
+  const HtmlBlockParser({required HtmlBlockChildrenParser parseChildren})
+      : _parseChildren = parseChildren;
+
+  static final RegExp _blockStartPattern = RegExp(
+    r'^<(?:div|p|center|blockquote)\b',
+    caseSensitive: false,
+  );
+  static final RegExp _horizontalRulePattern = RegExp(
+    r'^<hr\s*/?>$',
+    caseSensitive: false,
+  );
+
+  final HtmlBlockChildrenParser _parseChildren;
+
+  /// Recognizes a supported HTML block marker at the start of [line].
+  HtmlBlockMatch? probe(String line) {
+    if (!_couldStartHtmlLine(line)) return null;
+    final trimmed = line.trim();
+    if (_horizontalRulePattern.hasMatch(trimmed)) {
+      return const HtmlHorizontalRuleMatch();
+    }
+    if (!_blockStartPattern.hasMatch(trimmed)) return null;
+    final openTag = lexHtmlTag(trimmed, 0);
+    if (openTag == null || openTag.isClosing) return null;
+    return HtmlContainerBlockMatch(firstLine: trimmed, openTag: openTag);
+  }
+
+  /// Parses a block previously recognized by [probe].
+  HtmlBlockParseResult parseBlock(
+    List<String> lines,
+    int startIndex,
+    HtmlContainerBlockMatch match,
+  ) {
+    assert(startIndex >= 0 && startIndex < lines.length);
+    assert(lines[startIndex].trim() == match.firstLine);
+
+    final openTag = match.openTag;
+    final tagName = openTag.name;
+    final align = _parseAlignment(openTag);
+    if (openTag.isSelfClosing) {
+      return HtmlBlockParseResult(
+        node: _buildBlockNode(tagName, const <MarkdownNode>[], align),
+        linesConsumed: 1,
+      );
+    }
+
+    final contentLines = <String>[];
+    var nesting = 1;
+    var lineIndex = startIndex;
+    while (lineIndex < lines.length) {
+      final isFirst = lineIndex == startIndex;
+      final lineText = isFirst ? match.firstLine : lines[lineIndex];
+      final from = isFirst ? openTag.end : 0;
+      final scan = scanHtmlCloseTag(
+        lineText,
+        from,
+        tagName,
+        initialNesting: nesting,
+      );
+      nesting = scan.nesting;
+
+      final close = scan.close;
+      if (close != null) {
+        final before = lineText.substring(from, close.start);
+        final after = lineText.substring(close.end);
+        if (before.trim().isNotEmpty) contentLines.add(before);
+        if (after.trim().isNotEmpty) contentLines.add(after);
+        lineIndex++;
+        break;
+      }
+
+      final content = lineText.substring(from);
+      if (!isFirst || content.trim().isNotEmpty) contentLines.add(content);
+      lineIndex++;
+    }
+
+    final source = contentLines.join('\n');
+    final children =
+        source.trim().isEmpty ? const <MarkdownNode>[] : _parseChildren(source);
+    return HtmlBlockParseResult(
+      node: _buildBlockNode(tagName, children, align),
+      linesConsumed: lineIndex - startIndex,
+    );
+  }
+
+  static bool _couldStartHtmlLine(String line) {
+    if (line.isEmpty) return false;
+    final first = line.codeUnitAt(0);
+    return first <= 0x20 || first == 0x3C;
+  }
+
+  static HtmlBlockAlignment? _parseAlignment(HtmlTag tag) {
+    if (tag.name == 'center') return HtmlBlockAlignment.center;
+    return switch (tag.attributes['align']?.toLowerCase()) {
+      'left' => HtmlBlockAlignment.left,
+      'center' => HtmlBlockAlignment.center,
+      'right' => HtmlBlockAlignment.right,
+      _ => null,
+    };
+  }
+
+  static MarkdownNode _buildBlockNode(
+    String tag,
+    List<MarkdownNode> children,
+    HtmlBlockAlignment? align,
+  ) {
+    if (tag == 'blockquote') return BlockquoteNode(children);
+    return HtmlBlockNode(tag: tag, children: children, align: align);
+  }
+}

--- a/lib/src/parser/html/html_inline_parser.dart
+++ b/lib/src/parser/html/html_inline_parser.dart
@@ -181,7 +181,7 @@ class HtmlInlineParser {
   List<MarkdownNode> _buildHtmlImageNodes(HtmlTag tag) {
     final src = tag.attributes['src'] ?? '';
     final alt = tag.attributes['alt'] ?? '';
-    if (src.isEmpty || !isSafeHtmlUrl(src)) {
+    if (src.isEmpty || !isSafeHtmlImageSrc(src)) {
       return alt.isEmpty ? const [] : [TextNode(alt)];
     }
 

--- a/lib/src/parser/html/html_inline_parser.dart
+++ b/lib/src/parser/html/html_inline_parser.dart
@@ -1,0 +1,201 @@
+import '../ast/html_nodes.dart';
+import '../ast/markdown_node.dart';
+import 'html_utils.dart';
+
+/// Parses the children of a paired HTML tag at the supplied nesting [depth].
+typedef HtmlInlineChildrenParser = List<MarkdownNode> Function(
+  String source,
+  int depth,
+);
+
+/// Result of parsing one HTML tag, which may yield zero or more nodes.
+class HtmlInlineParseResult {
+  /// Creates an HTML inline parse result.
+  const HtmlInlineParseResult({
+    required this.nodes,
+    required this.consumed,
+  });
+
+  /// Nodes produced by the parsed HTML tag.
+  final List<MarkdownNode> nodes;
+
+  /// Number of source characters consumed.
+  final int consumed;
+}
+
+/// Parses supported inline HTML tags into Markdown AST nodes.
+///
+/// Unknown tags are stripped while retaining their parsed children. Invalid
+/// tags return `null` so callers can preserve the opening `<` as text.
+class HtmlInlineParser {
+  /// Creates an HTML inline parser using [parseChildren] for nested content.
+  const HtmlInlineParser({required HtmlInlineChildrenParser parseChildren})
+      : _parseChildren = parseChildren;
+
+  final HtmlInlineChildrenParser _parseChildren;
+
+  /// Attempts to parse an HTML tag starting at [start].
+  ///
+  /// [depth] is passed to nested child parsing after incrementing it by one.
+  HtmlInlineParseResult? tryParse(String text, int start, int depth) {
+    final tag = lexHtmlTag(text, start);
+    if (tag == null) return null;
+
+    final openConsumed = tag.end - start;
+    if (tag.isClosing) {
+      return HtmlInlineParseResult(nodes: const [], consumed: openConsumed);
+    }
+
+    final name = tag.name;
+    if (htmlVoidTags.contains(name)) {
+      return switch (name) {
+        'br' => HtmlInlineParseResult(
+            nodes: const [HardBreakNode()],
+            consumed: openConsumed,
+          ),
+        'img' => HtmlInlineParseResult(
+            nodes: _buildHtmlImageNodes(tag),
+            consumed: openConsumed,
+          ),
+        _ => HtmlInlineParseResult(nodes: const [], consumed: openConsumed),
+      };
+    }
+
+    if (tag.isSelfClosing) {
+      return HtmlInlineParseResult(nodes: const [], consumed: openConsumed);
+    }
+
+    final contentStart = tag.end;
+    final close = findHtmlCloseTag(text, contentStart, name);
+    final contentEnd = close?.start ?? text.length;
+    final consumed = (close?.end ?? text.length) - start;
+    final inner = text.substring(contentStart, contentEnd);
+
+    if (name == 'code') {
+      return HtmlInlineParseResult(
+        nodes: [InlineCodeNode(inner)],
+        consumed: consumed,
+      );
+    }
+
+    final children = _parseChildren(inner, depth + 1);
+    final node = _buildHtmlInlineNode(name, tag.attributes, children);
+    return HtmlInlineParseResult(
+      nodes: node != null ? [node] : children,
+      consumed: consumed,
+    );
+  }
+
+  MarkdownNode? _buildHtmlInlineNode(
+    String name,
+    Map<String, String> attributes,
+    List<MarkdownNode> children,
+  ) {
+    switch (name) {
+      case 'b':
+      case 'strong':
+        return BoldNode(children);
+      case 'i':
+      case 'em':
+        return ItalicNode(children);
+      case 's':
+      case 'del':
+      case 'strike':
+        return StrikethroughNode(children);
+      case 'u':
+      case 'ins':
+        return UnderlineNode(children);
+      case 'mark':
+        return HighlightNode(children);
+      case 'sub':
+        return SubscriptNode(children);
+      case 'sup':
+        return SuperscriptNode(children);
+      case 'kbd':
+        return KbdNode(children);
+      case 'a':
+        return _buildHtmlLinkNode(attributes, children);
+      case 'font':
+      case 'span':
+        return _buildStyledSpanNode(name, attributes, children);
+      default:
+        return null;
+    }
+  }
+
+  MarkdownNode? _buildHtmlLinkNode(
+    Map<String, String> attributes,
+    List<MarkdownNode> children,
+  ) {
+    final href = attributes['href'];
+    if (href == null || href.isEmpty || !isSafeHtmlUrl(href)) return null;
+
+    final title = attributes['title'];
+    return LinkNode(
+      url: href,
+      children: children,
+      title: title == null || title.isEmpty ? null : title,
+    );
+  }
+
+  MarkdownNode? _buildStyledSpanNode(
+    String name,
+    Map<String, String> attributes,
+    List<MarkdownNode> children,
+  ) {
+    int? color;
+    int? backgroundColor;
+    double? fontSize;
+
+    if (name == 'font') {
+      final colorAttr = attributes['color'];
+      if (colorAttr != null) color = parseHtmlColor(colorAttr);
+      final sizeAttr = attributes['size'];
+      if (sizeAttr != null) fontSize = parseFontSizeAttr(sizeAttr);
+    } else {
+      final style = attributes['style'];
+      if (style != null) {
+        final declarations = parseInlineCssDeclarations(style);
+        final colorValue = declarations['color'];
+        if (colorValue != null) color = parseHtmlColor(colorValue);
+        final backgroundValue = declarations['background-color'];
+        if (backgroundValue != null) {
+          backgroundColor = parseHtmlColor(backgroundValue);
+        }
+        final sizeValue = declarations['font-size'];
+        if (sizeValue != null) fontSize = parseHtmlFontSize(sizeValue);
+      }
+    }
+
+    if (color == null && backgroundColor == null && fontSize == null) {
+      return null;
+    }
+    return StyledSpanNode(
+      children: children,
+      color: color,
+      backgroundColor: backgroundColor,
+      fontSize: fontSize,
+    );
+  }
+
+  List<MarkdownNode> _buildHtmlImageNodes(HtmlTag tag) {
+    final src = tag.attributes['src'] ?? '';
+    final alt = tag.attributes['alt'] ?? '';
+    if (src.isEmpty || !isSafeHtmlUrl(src)) {
+      return alt.isEmpty ? const [] : [TextNode(alt)];
+    }
+
+    final title = tag.attributes['title'];
+    final width = tag.attributes['width'];
+    final height = tag.attributes['height'];
+    return [
+      ImageNode(
+        url: src,
+        alt: alt,
+        title: title == null || title.isEmpty ? null : title,
+        width: width == null ? null : parseHtmlDimension(width),
+        height: height == null ? null : parseHtmlDimension(height),
+      ),
+    ];
+  }
+}

--- a/lib/src/parser/html/html_utils.dart
+++ b/lib/src/parser/html/html_utils.dart
@@ -227,18 +227,18 @@ double? parseFontSizeAttr(String value) {
   return _legacyFontSizes[scale - 1];
 }
 
-/// Whether a URL from an HTML `href`/`src` attribute is safe to keep.
+/// Whether a URL from an HTML `href` attribute is safe to keep as a link.
 ///
-/// Scheme-less (relative, anchor, and protocol-relative) URLs are
-/// allowed; absolute URLs must use http, https, mailto, or tel.
+/// This is the policy for navigable links: scheme-less (relative, anchor,
+/// and protocol-relative) URLs are allowed, and absolute URLs must use
+/// http, https, mailto, or tel — schemes a launcher can hand off to the
+/// platform. Use [isSafeHtmlImageSrc] for `<img src>` instead, since image
+/// loaders support a narrower set of URLs than link navigation.
+///
 /// ASCII control characters and spaces are stripped before scheme
 /// detection so obfuscations such as `java\tscript:` are caught.
 bool isSafeHtmlUrl(String url) {
-  final buffer = StringBuffer();
-  for (final code in url.codeUnits) {
-    if (code > 0x20) buffer.writeCharCode(code);
-  }
-  final cleaned = buffer.toString();
+  final cleaned = _stripUnsafeUrlChars(url);
   if (cleaned.isEmpty) return false;
 
   for (var i = 0; i < cleaned.length; i++) {
@@ -252,6 +252,46 @@ bool isSafeHtmlUrl(String url) {
     }
   }
   return true; // No scheme at all.
+}
+
+/// Whether a URL from an HTML `src` attribute is safe to load as an image.
+///
+/// Image sources are constrained by what the renderer can actually load:
+/// network images require an absolute `http`/`https` URL and local images
+/// use a relative or absolute path resolved against bundled assets. This
+/// deliberately diverges from [isSafeHtmlUrl]: `mailto:` and `tel:` are
+/// nonsensical for images, and protocol-relative URLs (`//host/...`) have
+/// no base scheme to inherit and cannot be resolved by the image loaders.
+/// Accepting any of those would pass the safety check only to render a
+/// silent broken-image placeholder, so they are rejected here and fall
+/// back to the tag's alt text instead.
+bool isSafeHtmlImageSrc(String url) {
+  final cleaned = _stripUnsafeUrlChars(url);
+  if (cleaned.isEmpty) return false;
+
+  for (var i = 0; i < cleaned.length; i++) {
+    final char = cleaned[i];
+    if (char == '/' || char == '?' || char == '#') break; // No scheme.
+    if (char == ':') {
+      final scheme = cleaned.substring(0, i).toLowerCase();
+      return scheme == 'http' || scheme == 'https';
+    }
+  }
+
+  // Scheme-less: relative or absolute paths are local assets. Reject
+  // protocol-relative URLs (`//host/...`) — no base scheme to resolve.
+  return !cleaned.startsWith('//');
+}
+
+/// Strips ASCII control characters and spaces (anything `<= 0x20`) so
+/// obfuscations such as `java\tscript:` are normalized before scheme
+/// detection in [isSafeHtmlUrl] and [isSafeHtmlImageSrc].
+String _stripUnsafeUrlChars(String url) {
+  final buffer = StringBuffer();
+  for (final code in url.codeUnits) {
+    if (code > 0x20) buffer.writeCharCode(code);
+  }
+  return buffer.toString();
 }
 
 /// Location of a matching HTML closing tag found by [findHtmlCloseTag].

--- a/lib/src/parser/html/html_utils.dart
+++ b/lib/src/parser/html/html_utils.dart
@@ -13,12 +13,6 @@ const int maxHtmlTagLength = 512;
 /// HTML void tags that never have a matching closing tag.
 const Set<String> htmlVoidTags = {'br', 'hr', 'img'};
 
-/// Block-level HTML tags recognized at the start of a line.
-///
-/// `<details>`/`<summary>` are deliberately absent — they keep their
-/// dedicated parsing path in `BlockParser`.
-const Set<String> htmlBlockTags = {'div', 'p', 'center', 'blockquote'};
-
 /// URL schemes allowed for HTML `href`/`src` attributes.
 const Set<String> _allowedUrlSchemes = {'http', 'https', 'mailto', 'tel'};
 
@@ -121,26 +115,18 @@ HtmlTag? lexHtmlTag(String text, int start) {
     if (i >= limit) return null;
 
     final char = text[i];
-    if (char == '>') {
+    if (char == '>' || char == '/') {
+      final isSelfClosing = char == '/';
+      if (isSelfClosing && (i + 1 >= limit || text[i + 1] != '>')) {
+        return null;
+      }
       return HtmlTag(
         name: name,
         attributes: attributes,
         isClosing: isClosing,
-        isSelfClosing: false,
-        end: i + 1,
+        isSelfClosing: isSelfClosing,
+        end: i + (isSelfClosing ? 2 : 1),
       );
-    }
-    if (char == '/') {
-      if (i + 1 < limit && text[i + 1] == '>') {
-        return HtmlTag(
-          name: name,
-          attributes: attributes,
-          isClosing: isClosing,
-          isSelfClosing: true,
-          end: i + 2,
-        );
-      }
-      return null;
     }
 
     // Attribute name: [a-zA-Z][a-zA-Z0-9-]*

--- a/lib/src/parser/html/html_utils.dart
+++ b/lib/src/parser/html/html_utils.dart
@@ -293,7 +293,9 @@ HtmlCloseTagLocation? findHtmlCloseTag(String text, int from, String name) {
   var nesting = 1;
   var i = from;
   while (i < text.length) {
-    if (text[i] != '<') {
+    // 0x3C == '<'; codeUnitAt avoids a per-character string allocation
+    // in this forward scan, which runs over the whole tag content.
+    if (text.codeUnitAt(i) != 0x3C) {
       i++;
       continue;
     }

--- a/lib/src/parser/html/html_utils.dart
+++ b/lib/src/parser/html/html_utils.dart
@@ -163,7 +163,7 @@ HtmlTag? lexHtmlTag(String text, int start) {
         value = text.substring(valueStart, i);
       }
     }
-    attributes.putIfAbsent(attrName, () => value);
+    if (!attributes.containsKey(attrName)) attributes[attrName] = value;
   }
 }
 
@@ -179,16 +179,12 @@ int? parseHtmlColor(String value) {
 
   if (v.startsWith('#')) {
     final hex = v.substring(1);
-    if (hex.length == 3) {
-      final expanded = hex.split('').map((c) => '$c$c').join();
-      final parsed = int.tryParse(expanded, radix: 16);
-      return parsed == null ? null : 0xFF000000 | parsed;
-    }
-    if (hex.length == 6) {
-      final parsed = int.tryParse(hex, radix: 16);
-      return parsed == null ? null : 0xFF000000 | parsed;
-    }
-    return null;
+    // Expand shorthand `#RGB` to `#RRGGBB` so both forms parse once.
+    final normalized =
+        hex.length == 3 ? hex.split('').map((c) => '$c$c').join() : hex;
+    if (normalized.length != 6) return null;
+    final parsed = int.tryParse(normalized, radix: 16);
+    return parsed == null ? null : 0xFF000000 | parsed;
   }
   return _namedColors[v];
 }
@@ -270,13 +266,23 @@ class HtmlCloseTagLocation {
   final int end;
 }
 
-/// Finds the closing tag matching an already-consumed open [name] tag.
+/// Result of a forward scan for a matching HTML close tag.
+typedef HtmlCloseTagScan = ({int nesting, HtmlCloseTagLocation? close});
+
+/// Scans forward from [from] for the close tag matching an already-consumed
+/// open [name] tag, tracking same-name nesting across the whole scan.
 ///
-/// [from] is the index right after the open tag. A same-name nesting
-/// counter ensures nested tags of the same name close at matching
-/// depth. Returns `null` when no matching close tag exists in [text].
-HtmlCloseTagLocation? findHtmlCloseTag(String text, int from, String name) {
-  var nesting = 1;
+/// [initialNesting] is the nesting depth at [from] (normally `1`, right
+/// after a single open tag). The returned `nesting` field is the depth at
+/// the end of [text]; the `close` field is the location of the terminating
+/// close tag when nesting reaches zero, otherwise `null`.
+HtmlCloseTagScan scanHtmlCloseTag(
+  String text,
+  int from,
+  String name, {
+  int initialNesting = 1,
+}) {
+  var nesting = initialNesting;
   var i = from;
   while (i < text.length) {
     // 0x3C == '<'; codeUnitAt avoids a per-character string allocation
@@ -294,7 +300,10 @@ HtmlCloseTagLocation? findHtmlCloseTag(String text, int from, String name) {
       if (tag.isClosing) {
         nesting--;
         if (nesting == 0) {
-          return HtmlCloseTagLocation(start: i, end: tag.end);
+          return (
+            nesting: 0,
+            close: HtmlCloseTagLocation(start: i, end: tag.end),
+          );
         }
       } else if (!tag.isSelfClosing) {
         nesting++;
@@ -302,7 +311,16 @@ HtmlCloseTagLocation? findHtmlCloseTag(String text, int from, String name) {
     }
     i = tag.end;
   }
-  return null;
+  return (nesting: nesting, close: null);
+}
+
+/// Finds the closing tag matching an already-consumed open [name] tag.
+///
+/// Equivalent to [scanHtmlCloseTag] with an initial nesting of `1`,
+/// returning only the close location. Returns `null` when no matching
+/// close tag exists in [text].
+HtmlCloseTagLocation? findHtmlCloseTag(String text, int from, String name) {
+  return scanHtmlCloseTag(text, from, name).close;
 }
 
 /// Splits an inline CSS `style` attribute into property declarations.
@@ -318,7 +336,7 @@ Map<String, String> parseInlineCssDeclarations(String style) {
     final name = part.substring(0, colon).trim().toLowerCase();
     final value = part.substring(colon + 1).trim();
     if (name.isEmpty || value.isEmpty) continue;
-    declarations.putIfAbsent(name, () => value);
+    if (!declarations.containsKey(name)) declarations[name] = value;
   }
   return declarations;
 }

--- a/lib/src/parser/html/html_utils.dart
+++ b/lib/src/parser/html/html_utils.dart
@@ -1,0 +1,290 @@
+/// Utilities for lexing and sanitizing whitelisted HTML tags.
+///
+/// These helpers are pure Dart (no Flutter imports) so the parser layer
+/// stays platform independent and isolate friendly.
+library;
+
+/// Maximum number of characters a single HTML tag may span.
+///
+/// Lexing gives up beyond this bound to avoid quadratic scans on
+/// pathological input such as a `<a href="...` with no closing bracket.
+const int maxHtmlTagLength = 512;
+
+/// HTML void tags that never have a matching closing tag.
+const Set<String> htmlVoidTags = {'br', 'hr', 'img'};
+
+/// Block-level HTML tags recognized at the start of a line.
+///
+/// `<details>`/`<summary>` are deliberately absent — they keep their
+/// dedicated parsing path in `BlockParser`.
+const Set<String> htmlBlockTags = {'div', 'p', 'center', 'blockquote'};
+
+/// URL schemes allowed for HTML `href`/`src` attributes.
+const Set<String> _allowedUrlSchemes = {'http', 'https', 'mailto', 'tel'};
+
+/// Bounds for accepted CSS font sizes in logical pixels.
+const double _minFontSize = 4;
+const double _maxFontSize = 128;
+
+/// Pixel sizes for the legacy `<font size="1..7">` scale.
+const List<double> _legacyFontSizes = [10, 13, 16, 18, 24, 32, 48];
+
+/// Named CSS colors accepted by [parseHtmlColor] (ARGB values).
+const Map<String, int> _namedColors = {
+  'aqua': 0xFF00FFFF,
+  'black': 0xFF000000,
+  'blue': 0xFF0000FF,
+  'brown': 0xFFA52A2A,
+  'cyan': 0xFF00FFFF,
+  'fuchsia': 0xFFFF00FF,
+  'gold': 0xFFFFD700,
+  'gray': 0xFF808080,
+  'green': 0xFF008000,
+  'grey': 0xFF808080,
+  'indigo': 0xFF4B0082,
+  'lime': 0xFF00FF00,
+  'magenta': 0xFFFF00FF,
+  'maroon': 0xFF800000,
+  'navy': 0xFF000080,
+  'olive': 0xFF808000,
+  'orange': 0xFFFFA500,
+  'pink': 0xFFFFC0CB,
+  'purple': 0xFF800080,
+  'red': 0xFFFF0000,
+  'silver': 0xFFC0C0C0,
+  'teal': 0xFF008080,
+  'violet': 0xFFEE82EE,
+  'white': 0xFFFFFFFF,
+  'yellow': 0xFFFFFF00,
+};
+
+/// A single lexed HTML tag such as `<img src="a.png">` or `</div>`.
+class HtmlTag {
+  /// Creates a new lexed HTML tag.
+  const HtmlTag({
+    required this.name,
+    required this.attributes,
+    required this.isClosing,
+    required this.isSelfClosing,
+    required this.end,
+  });
+
+  /// The lowercased tag name (for example `div` or `br`).
+  final String name;
+
+  /// Attributes with lowercased names; first occurrence wins.
+  ///
+  /// Valueless boolean attributes map to an empty string.
+  final Map<String, String> attributes;
+
+  /// Whether this is a closing tag (`</name>`).
+  final bool isClosing;
+
+  /// Whether this tag is explicitly self-closed (`<name ... />`).
+  final bool isSelfClosing;
+
+  /// Index into the source text just past the closing `>`.
+  final int end;
+}
+
+/// Lexes a single HTML tag starting at `text[start]` (which must be `<`).
+///
+/// Returns `null` when the text at [start] is not a syntactically valid
+/// tag — for example `<3`, `< b>`, an unterminated quote, or a tag
+/// longer than [maxHtmlTagLength]. Callers treat `null` as literal text.
+HtmlTag? lexHtmlTag(String text, int start) {
+  final limit = text.length < start + maxHtmlTagLength
+      ? text.length
+      : start + maxHtmlTagLength;
+  var i = start;
+  if (i >= limit || text[i] != '<') return null;
+  i++;
+
+  var isClosing = false;
+  if (i < limit && text[i] == '/') {
+    isClosing = true;
+    i++;
+  }
+
+  // Tag name: [a-zA-Z][a-zA-Z0-9-]*
+  if (i >= limit || !_isAsciiLetter(text.codeUnitAt(i))) return null;
+  final nameStart = i;
+  i++;
+  while (i < limit && _isNameChar(text.codeUnitAt(i))) {
+    i++;
+  }
+  final name = text.substring(nameStart, i).toLowerCase();
+
+  final attributes = <String, String>{};
+  while (true) {
+    i = _skipWhitespace(text, i, limit);
+    if (i >= limit) return null;
+
+    final char = text[i];
+    if (char == '>') {
+      return HtmlTag(
+        name: name,
+        attributes: attributes,
+        isClosing: isClosing,
+        isSelfClosing: false,
+        end: i + 1,
+      );
+    }
+    if (char == '/') {
+      if (i + 1 < limit && text[i + 1] == '>') {
+        return HtmlTag(
+          name: name,
+          attributes: attributes,
+          isClosing: isClosing,
+          isSelfClosing: true,
+          end: i + 2,
+        );
+      }
+      return null;
+    }
+
+    // Attribute name: [a-zA-Z][a-zA-Z0-9-]*
+    if (!_isAsciiLetter(text.codeUnitAt(i))) return null;
+    final attrNameStart = i;
+    i++;
+    while (i < limit && _isNameChar(text.codeUnitAt(i))) {
+      i++;
+    }
+    final attrName = text.substring(attrNameStart, i).toLowerCase();
+
+    i = _skipWhitespace(text, i, limit);
+    var value = '';
+    if (i < limit && text[i] == '=') {
+      i++;
+      i = _skipWhitespace(text, i, limit);
+      if (i >= limit) return null;
+      final quote = text[i];
+      if (quote == '"' || quote == "'") {
+        i++;
+        final valueStart = i;
+        while (i < limit && text[i] != quote) {
+          i++;
+        }
+        if (i >= limit) return null; // Unterminated quote
+        value = text.substring(valueStart, i);
+        i++;
+      } else {
+        final valueStart = i;
+        while (
+            i < limit && !_isWhitespace(text.codeUnitAt(i)) && text[i] != '>') {
+          i++;
+        }
+        value = text.substring(valueStart, i);
+      }
+    }
+    attributes.putIfAbsent(attrName, () => value);
+  }
+}
+
+/// Parses an HTML/CSS color value into an ARGB integer.
+///
+/// Accepts `#RGB`, `#RRGGBB`, and a set of common named colors.
+/// Eight-digit hex is rejected because CSS (`#RRGGBBAA`) and Flutter
+/// (`AARRGGBB`) disagree on channel order. Returns `null` when the
+/// value is not recognized.
+int? parseHtmlColor(String value) {
+  final v = value.trim().toLowerCase();
+  if (v.isEmpty) return null;
+
+  if (v.startsWith('#')) {
+    final hex = v.substring(1);
+    if (hex.length == 3) {
+      final expanded = hex.split('').map((c) => '$c$c').join();
+      final parsed = int.tryParse(expanded, radix: 16);
+      return parsed == null ? null : 0xFF000000 | parsed;
+    }
+    if (hex.length == 6) {
+      final parsed = int.tryParse(hex, radix: 16);
+      return parsed == null ? null : 0xFF000000 | parsed;
+    }
+    return null;
+  }
+  return _namedColors[v];
+}
+
+/// Parses a CSS `font-size` value into logical pixels.
+///
+/// Accepts `px`, `pt` (converted at 4/3), and bare numbers. Relative
+/// units (`em`, `%`) and keywords are rejected, as are sizes outside
+/// a safe display range. Returns `null` when not accepted.
+double? parseHtmlFontSize(String value) {
+  final v = value.trim().toLowerCase();
+  if (v.isEmpty) return null;
+
+  double? size;
+  if (v.endsWith('px')) {
+    size = double.tryParse(v.substring(0, v.length - 2).trim());
+  } else if (v.endsWith('pt')) {
+    final points = double.tryParse(v.substring(0, v.length - 2).trim());
+    size = points == null ? null : points * 4 / 3;
+  } else {
+    size = double.tryParse(v);
+  }
+
+  if (size == null || size < _minFontSize || size > _maxFontSize) {
+    return null;
+  }
+  return size;
+}
+
+/// Parses the legacy `<font size="1..7">` attribute into pixels.
+///
+/// Relative values such as `+2` and out-of-range numbers return `null`.
+double? parseFontSizeAttr(String value) {
+  final v = value.trim();
+  if (v.isEmpty || v.startsWith('+') || v.startsWith('-')) return null;
+  final scale = int.tryParse(v);
+  if (scale == null || scale < 1 || scale > _legacyFontSizes.length) {
+    return null;
+  }
+  return _legacyFontSizes[scale - 1];
+}
+
+/// Whether a URL from an HTML `href`/`src` attribute is safe to keep.
+///
+/// Scheme-less (relative, anchor, and protocol-relative) URLs are
+/// allowed; absolute URLs must use http, https, mailto, or tel.
+/// ASCII control characters and spaces are stripped before scheme
+/// detection so obfuscations such as `java\tscript:` are caught.
+bool isSafeHtmlUrl(String url) {
+  final buffer = StringBuffer();
+  for (final code in url.codeUnits) {
+    if (code > 0x20) buffer.writeCharCode(code);
+  }
+  final cleaned = buffer.toString();
+  if (cleaned.isEmpty) return false;
+
+  for (var i = 0; i < cleaned.length; i++) {
+    final char = cleaned[i];
+    if (char == '/' || char == '?' || char == '#') {
+      return true; // Path/query/fragment before any scheme.
+    }
+    if (char == ':') {
+      final scheme = cleaned.substring(0, i).toLowerCase();
+      return _allowedUrlSchemes.contains(scheme);
+    }
+  }
+  return true; // No scheme at all.
+}
+
+int _skipWhitespace(String text, int index, int limit) {
+  var i = index;
+  while (i < limit && _isWhitespace(text.codeUnitAt(i))) {
+    i++;
+  }
+  return i;
+}
+
+bool _isWhitespace(int code) =>
+    code == 0x20 || code == 0x09 || code == 0x0A || code == 0x0D;
+
+bool _isAsciiLetter(int code) =>
+    (code >= 0x41 && code <= 0x5A) || (code >= 0x61 && code <= 0x7A);
+
+bool _isNameChar(int code) =>
+    _isAsciiLetter(code) || (code >= 0x30 && code <= 0x39) || code == 0x2D;

--- a/lib/src/parser/html/html_utils.dart
+++ b/lib/src/parser/html/html_utils.dart
@@ -272,6 +272,51 @@ bool isSafeHtmlUrl(String url) {
   return true; // No scheme at all.
 }
 
+/// Location of a matching HTML closing tag found by [findHtmlCloseTag].
+class HtmlCloseTagLocation {
+  /// Creates a new closing tag location.
+  const HtmlCloseTagLocation({required this.start, required this.end});
+
+  /// Index of the `<` of the closing tag.
+  final int start;
+
+  /// Index just past the `>` of the closing tag.
+  final int end;
+}
+
+/// Finds the closing tag matching an already-consumed open [name] tag.
+///
+/// [from] is the index right after the open tag. A same-name nesting
+/// counter ensures nested tags of the same name close at matching
+/// depth. Returns `null` when no matching close tag exists in [text].
+HtmlCloseTagLocation? findHtmlCloseTag(String text, int from, String name) {
+  var nesting = 1;
+  var i = from;
+  while (i < text.length) {
+    if (text[i] != '<') {
+      i++;
+      continue;
+    }
+    final tag = lexHtmlTag(text, i);
+    if (tag == null) {
+      i++;
+      continue;
+    }
+    if (tag.name == name) {
+      if (tag.isClosing) {
+        nesting--;
+        if (nesting == 0) {
+          return HtmlCloseTagLocation(start: i, end: tag.end);
+        }
+      } else if (!tag.isSelfClosing) {
+        nesting++;
+      }
+    }
+    i = tag.end;
+  }
+  return null;
+}
+
 /// Splits an inline CSS `style` attribute into property declarations.
 ///
 /// Property names are lowercased and trimmed; values are trimmed with

--- a/lib/src/parser/html/html_utils.dart
+++ b/lib/src/parser/html/html_utils.dart
@@ -272,6 +272,41 @@ bool isSafeHtmlUrl(String url) {
   return true; // No scheme at all.
 }
 
+/// Splits an inline CSS `style` attribute into property declarations.
+///
+/// Property names are lowercased and trimmed; values are trimmed with
+/// their original casing preserved. Malformed declarations are skipped
+/// and the first occurrence of a property wins.
+Map<String, String> parseInlineCssDeclarations(String style) {
+  final declarations = <String, String>{};
+  for (final part in style.split(';')) {
+    final colon = part.indexOf(':');
+    if (colon <= 0) continue;
+    final name = part.substring(0, colon).trim().toLowerCase();
+    final value = part.substring(colon + 1).trim();
+    if (name.isEmpty || value.isEmpty) continue;
+    declarations.putIfAbsent(name, () => value);
+  }
+  return declarations;
+}
+
+/// Parses an HTML `width`/`height` attribute into logical pixels.
+///
+/// Accepts positive numbers with an optional `px` suffix, capped at a
+/// sane upper bound. Percentages and other units return `null`.
+double? parseHtmlDimension(String value) {
+  var v = value.trim().toLowerCase();
+  if (v.endsWith('px')) {
+    v = v.substring(0, v.length - 2).trim();
+  }
+  final size = double.tryParse(v);
+  if (size == null || size <= 0 || size > _maxDimension) return null;
+  return size;
+}
+
+/// Upper bound for accepted image dimensions in logical pixels.
+const double _maxDimension = 10000;
+
 int _skipWhitespace(String text, int index, int limit) {
   var i = index;
   while (i < limit && _isWhitespace(text.codeUnitAt(i))) {

--- a/lib/src/parser/inline_parser.dart
+++ b/lib/src/parser/inline_parser.dart
@@ -646,34 +646,35 @@ class InlineParser {
     final tag = lexHtmlTag(text, start);
     if (tag == null) return null;
 
+    // Span consumed by tags that carry no separate close tag.
+    final openConsumed = tag.end - start;
+
     // Stray closing tag with no matching open tag: consume silently.
     if (tag.isClosing) {
-      return _HtmlParseResult(nodes: const [], consumed: tag.end - start);
+      return _HtmlParseResult(nodes: const [], consumed: openConsumed);
     }
 
     final name = tag.name;
 
     // Void tags produce leaf nodes directly.
-    if (name == 'br') {
-      return _HtmlParseResult(
-        nodes: const [HardBreakNode()],
-        consumed: tag.end - start,
-      );
-    }
-    if (name == 'img') {
-      return _HtmlParseResult(
-        nodes: _buildHtmlImageNodes(tag),
-        consumed: tag.end - start,
-      );
-    }
-    if (name == 'hr') {
-      // An inline <hr> has no meaningful inline rendering.
-      return _HtmlParseResult(nodes: const [], consumed: tag.end - start);
+    if (htmlVoidTags.contains(name)) {
+      return switch (name) {
+        'br' => _HtmlParseResult(
+            nodes: const [HardBreakNode()],
+            consumed: openConsumed,
+          ),
+        'img' => _HtmlParseResult(
+            nodes: _buildHtmlImageNodes(tag),
+            consumed: openConsumed,
+          ),
+        // An inline <hr> has no meaningful inline rendering.
+        _ => _HtmlParseResult(nodes: const [], consumed: openConsumed),
+      };
     }
 
     // Explicitly self-closed non-void tags produce nothing.
     if (tag.isSelfClosing) {
-      return _HtmlParseResult(nodes: const [], consumed: tag.end - start);
+      return _HtmlParseResult(nodes: const [], consumed: openConsumed);
     }
 
     // Paired tag: find the matching close with a same-name counter.

--- a/lib/src/parser/inline_parser.dart
+++ b/lib/src/parser/inline_parser.dart
@@ -1,4 +1,6 @@
+import 'ast/html_nodes.dart';
 import 'ast/markdown_node.dart';
+import 'html/html_utils.dart';
 import 'parser_plugin.dart';
 
 /// Parser for inline-level Markdown elements
@@ -10,22 +12,31 @@ import 'parser_plugin.dart';
 /// - Links ([text](url))
 /// - Images (![alt](url))
 /// - Strikethrough (~~text~~)
+/// - Whitelisted HTML tags (when [InlineParser.new] `enableHtml` is set)
 ///
 /// Supports custom inline plugins through [ParserPluginRegistry].
 class InlineParser {
   /// Creates a new inline parser
   ///
   /// Optionally accepts a [ParserPluginRegistry] for custom inline plugins.
-  InlineParser({ParserPluginRegistry? plugins}) : _plugins = plugins;
+  /// When [enableHtml] is true, whitelisted inline HTML tags such as
+  /// `<b>`, `<mark>`, or `<img>` are parsed; unknown tags are stripped
+  /// while their content is kept.
+  InlineParser({ParserPluginRegistry? plugins, bool enableHtml = false})
+      : _plugins = plugins,
+        _enableHtml = enableHtml;
 
   /// Plugin registry for custom inline parsers
   final ParserPluginRegistry? _plugins;
+
+  /// Whether whitelisted inline HTML tags are parsed
+  final bool _enableHtml;
 
   /// Maximum recursion depth to prevent stack overflow on deeply nested input
   static const _maxDepth = 16;
 
   /// Characters that can be escaped with backslash per CommonMark spec
-  static const _escapableChars = r'\`*_{}[]()#+-.!~$|>';
+  static const _escapableChars = r'\`*_{}[]()#+-.!~$|><';
 
   /// Parses inline elements from text
   List<MarkdownNode> parse(String text, {int depth = 0}) {
@@ -98,6 +109,18 @@ class InlineParser {
         if (result != null) {
           node = result.node;
           consumed = result.consumed;
+        }
+      }
+
+      // Try HTML tag (may yield zero or several nodes, so it bypasses
+      // the single-node flow and continues the loop directly)
+      if (node == null && _enableHtml && text[i] == '<') {
+        final result = _tryParseHtmlTag(text, i, depth);
+        if (result != null) {
+          assert(result.consumed > 0, 'HTML parsing must consume input');
+          nodes.addAll(result.nodes);
+          i += result.consumed;
+          continue;
         }
       }
 
@@ -540,7 +563,8 @@ class InlineParser {
           char == '~' ||
           char == '[' ||
           char == '!' ||
-          char == '\$') {
+          char == '\$' ||
+          (_enableHtml && char == '<')) {
         break;
       }
 
@@ -580,6 +604,246 @@ class InlineParser {
     return null;
   }
 
+  /// Tries to parse a whitelisted HTML tag at [start].
+  ///
+  /// Returns `null` when the text is not a syntactically valid tag, so
+  /// the `<` character falls through as literal text. Valid but unknown
+  /// tags are stripped while their inner content is kept. Unclosed
+  /// whitelisted tags are auto-closed at the end of the text, which
+  /// keeps streaming (incremental re-parse) rendering stable.
+  _HtmlParseResult? _tryParseHtmlTag(String text, int start, int depth) {
+    final tag = lexHtmlTag(text, start);
+    if (tag == null) return null;
+
+    // Stray closing tag with no matching open tag: consume silently.
+    if (tag.isClosing) {
+      return _HtmlParseResult(nodes: const [], consumed: tag.end - start);
+    }
+
+    final name = tag.name;
+
+    // Void tags produce leaf nodes directly.
+    if (name == 'br') {
+      return _HtmlParseResult(
+        nodes: const [HardBreakNode()],
+        consumed: tag.end - start,
+      );
+    }
+    if (name == 'img') {
+      return _HtmlParseResult(
+        nodes: _buildHtmlImageNodes(tag),
+        consumed: tag.end - start,
+      );
+    }
+    if (name == 'hr') {
+      // An inline <hr> has no meaningful inline rendering.
+      return _HtmlParseResult(nodes: const [], consumed: tag.end - start);
+    }
+
+    // Explicitly self-closed non-void tags produce nothing.
+    if (tag.isSelfClosing) {
+      return _HtmlParseResult(nodes: const [], consumed: tag.end - start);
+    }
+
+    // Paired tag: find the matching close with a same-name counter.
+    // A missing close tag auto-closes at the end of the text.
+    final contentStart = tag.end;
+    final close = _findHtmlCloseTag(text, contentStart, name);
+    final contentEnd = close?.start ?? text.length;
+    final consumed = (close?.end ?? text.length) - start;
+    final inner = text.substring(contentStart, contentEnd);
+
+    // <code> keeps its content verbatim, like a backtick code span.
+    if (name == 'code') {
+      return _HtmlParseResult(
+        nodes: [InlineCodeNode(inner)],
+        consumed: consumed,
+      );
+    }
+
+    final children = parse(inner, depth: depth + 1);
+    final node = _buildHtmlInlineNode(name, tag.attributes, children);
+
+    // Unknown tags (and spans without usable styles) are stripped:
+    // their children are spliced into the surrounding content.
+    return _HtmlParseResult(
+      nodes: node != null ? [node] : children,
+      consumed: consumed,
+    );
+  }
+
+  /// Finds the closing tag matching an open [name] tag.
+  ///
+  /// [from] is the index right after the open tag. Uses a same-name
+  /// counter so nested tags of the same name close at matching depth.
+  /// Returns `null` when no matching close tag exists.
+  _HtmlCloseTag? _findHtmlCloseTag(String text, int from, String name) {
+    var nesting = 1;
+    var i = from;
+    while (i < text.length) {
+      if (text[i] != '<') {
+        i++;
+        continue;
+      }
+      final tag = lexHtmlTag(text, i);
+      if (tag == null) {
+        i++;
+        continue;
+      }
+      if (tag.name == name) {
+        if (tag.isClosing) {
+          nesting--;
+          if (nesting == 0) {
+            return _HtmlCloseTag(start: i, end: tag.end);
+          }
+        } else if (!tag.isSelfClosing) {
+          nesting++;
+        }
+      }
+      i = tag.end;
+    }
+    return null;
+  }
+
+  /// Maps a whitelisted inline HTML tag to its AST node.
+  ///
+  /// Returns `null` for unknown tags and for `a`/`span`/`font` tags
+  /// without usable attributes, which callers treat as "strip the tag
+  /// and keep the children".
+  MarkdownNode? _buildHtmlInlineNode(
+    String name,
+    Map<String, String> attributes,
+    List<MarkdownNode> children,
+  ) {
+    switch (name) {
+      case 'b':
+      case 'strong':
+        return BoldNode(children);
+      case 'i':
+      case 'em':
+        return ItalicNode(children);
+      case 's':
+      case 'del':
+      case 'strike':
+        return StrikethroughNode(children);
+      case 'u':
+      case 'ins':
+        return UnderlineNode(children);
+      case 'mark':
+        return HighlightNode(children);
+      case 'sub':
+        return SubscriptNode(children);
+      case 'sup':
+        return SuperscriptNode(children);
+      case 'kbd':
+        return KbdNode(children);
+      case 'a':
+        return _buildHtmlLinkNode(attributes, children);
+      case 'font':
+      case 'span':
+        return _buildStyledSpanNode(name, attributes, children);
+      default:
+        return null;
+    }
+  }
+
+  /// Builds a [LinkNode] from `<a>` attributes.
+  ///
+  /// Returns `null` (strip tag, keep children) when the `href` is
+  /// missing, empty, or uses an unsafe scheme.
+  MarkdownNode? _buildHtmlLinkNode(
+    Map<String, String> attributes,
+    List<MarkdownNode> children,
+  ) {
+    final href = attributes['href'];
+    if (href == null || href.isEmpty || !isSafeHtmlUrl(href)) {
+      return null;
+    }
+    final title = attributes['title'];
+    return LinkNode(
+      url: href,
+      children: children,
+      title: title == null || title.isEmpty ? null : title,
+    );
+  }
+
+  /// Builds a [StyledSpanNode] from `<font>` attributes or a `<span>`
+  /// `style` attribute.
+  ///
+  /// Only the safe subset (color, background color, font size) is
+  /// honored; all other styling is ignored. Returns `null` when no
+  /// usable style remains.
+  MarkdownNode? _buildStyledSpanNode(
+    String name,
+    Map<String, String> attributes,
+    List<MarkdownNode> children,
+  ) {
+    int? color;
+    int? backgroundColor;
+    double? fontSize;
+
+    if (name == 'font') {
+      final colorAttr = attributes['color'];
+      if (colorAttr != null) {
+        color = parseHtmlColor(colorAttr);
+      }
+      final sizeAttr = attributes['size'];
+      if (sizeAttr != null) {
+        fontSize = parseFontSizeAttr(sizeAttr);
+      }
+    } else {
+      final style = attributes['style'];
+      if (style != null) {
+        final declarations = parseInlineCssDeclarations(style);
+        final colorValue = declarations['color'];
+        if (colorValue != null) {
+          color = parseHtmlColor(colorValue);
+        }
+        final backgroundValue = declarations['background-color'];
+        if (backgroundValue != null) {
+          backgroundColor = parseHtmlColor(backgroundValue);
+        }
+        final sizeValue = declarations['font-size'];
+        if (sizeValue != null) {
+          fontSize = parseHtmlFontSize(sizeValue);
+        }
+      }
+    }
+
+    if (color == null && backgroundColor == null && fontSize == null) {
+      return null;
+    }
+    return StyledSpanNode(
+      children: children,
+      color: color,
+      backgroundColor: backgroundColor,
+      fontSize: fontSize,
+    );
+  }
+
+  /// Builds the nodes for an `<img>` tag.
+  ///
+  /// An unsafe or missing `src` degrades to the alt text (or nothing).
+  List<MarkdownNode> _buildHtmlImageNodes(HtmlTag tag) {
+    final src = tag.attributes['src'] ?? '';
+    final alt = tag.attributes['alt'] ?? '';
+    if (src.isEmpty || !isSafeHtmlUrl(src)) {
+      return alt.isEmpty ? const [] : [TextNode(alt)];
+    }
+    final title = tag.attributes['title'];
+    final width = tag.attributes['width'];
+    final height = tag.attributes['height'];
+    return [
+      ImageNode(
+        url: src,
+        alt: alt,
+        title: title == null || title.isEmpty ? null : title,
+        width: width == null ? null : parseHtmlDimension(width),
+        height: height == null ? null : parseHtmlDimension(height),
+      ),
+    ];
+  }
+
   /// Merges consecutive TextNode instances
   List<MarkdownNode> _mergeTextNodes(List<MarkdownNode> nodes) {
     if (nodes.isEmpty) return nodes;
@@ -617,6 +881,31 @@ class _InlineParseResult {
 
   final MarkdownNode node;
   final int consumed;
+}
+
+/// Result of parsing an HTML tag, which may yield zero or more nodes
+class _HtmlParseResult {
+  const _HtmlParseResult({
+    required this.nodes,
+    required this.consumed,
+  });
+
+  final List<MarkdownNode> nodes;
+  final int consumed;
+}
+
+/// Location of a matching HTML closing tag
+class _HtmlCloseTag {
+  const _HtmlCloseTag({
+    required this.start,
+    required this.end,
+  });
+
+  /// Index of the `<` of the closing tag
+  final int start;
+
+  /// Index just past the `>` of the closing tag
+  final int end;
 }
 
 /// URL and optional title

--- a/lib/src/parser/inline_parser.dart
+++ b/lib/src/parser/inline_parser.dart
@@ -1,6 +1,5 @@
-import 'ast/html_nodes.dart';
 import 'ast/markdown_node.dart';
-import 'html/html_utils.dart';
+import 'html/html_inline_parser.dart';
 import 'parser_plugin.dart';
 
 /// Parser for inline-level Markdown elements
@@ -31,6 +30,12 @@ class InlineParser {
 
   /// Whether whitelisted inline HTML tags are parsed
   final bool _enableHtml;
+
+  late final HtmlInlineParser? _htmlParser = _enableHtml
+      ? HtmlInlineParser(
+          parseChildren: (source, depth) => parse(source, depth: depth),
+        )
+      : null;
 
   /// Maximum recursion depth to prevent stack overflow on deeply nested input
   static const _maxDepth = 16;
@@ -118,7 +123,7 @@ class InlineParser {
           _enableHtml &&
           text[i] == '<' &&
           _canStartHtmlTag(text, i)) {
-        final result = _tryParseHtmlTag(text, i, depth);
+        final result = _htmlParser!.tryParse(text, i, depth);
         if (result != null) {
           assert(result.consumed > 0, 'HTML parsing must consume input');
           nodes.addAll(result.nodes);
@@ -635,214 +640,6 @@ class InlineParser {
     return null;
   }
 
-  /// Tries to parse a whitelisted HTML tag at [start].
-  ///
-  /// Returns `null` when the text is not a syntactically valid tag, so
-  /// the `<` character falls through as literal text. Valid but unknown
-  /// tags are stripped while their inner content is kept. Unclosed
-  /// whitelisted tags are auto-closed at the end of the text, which
-  /// keeps streaming (incremental re-parse) rendering stable.
-  _HtmlParseResult? _tryParseHtmlTag(String text, int start, int depth) {
-    final tag = lexHtmlTag(text, start);
-    if (tag == null) return null;
-
-    // Span consumed by tags that carry no separate close tag.
-    final openConsumed = tag.end - start;
-
-    // Stray closing tag with no matching open tag: consume silently.
-    if (tag.isClosing) {
-      return _HtmlParseResult(nodes: const [], consumed: openConsumed);
-    }
-
-    final name = tag.name;
-
-    // Void tags produce leaf nodes directly.
-    if (htmlVoidTags.contains(name)) {
-      return switch (name) {
-        'br' => _HtmlParseResult(
-            nodes: const [HardBreakNode()],
-            consumed: openConsumed,
-          ),
-        'img' => _HtmlParseResult(
-            nodes: _buildHtmlImageNodes(tag),
-            consumed: openConsumed,
-          ),
-        // An inline <hr> has no meaningful inline rendering.
-        _ => _HtmlParseResult(nodes: const [], consumed: openConsumed),
-      };
-    }
-
-    // Explicitly self-closed non-void tags produce nothing.
-    if (tag.isSelfClosing) {
-      return _HtmlParseResult(nodes: const [], consumed: openConsumed);
-    }
-
-    // Paired tag: find the matching close with a same-name counter.
-    // A missing close tag auto-closes at the end of the text.
-    final contentStart = tag.end;
-    final close = findHtmlCloseTag(text, contentStart, name);
-    final contentEnd = close?.start ?? text.length;
-    final consumed = (close?.end ?? text.length) - start;
-    final inner = text.substring(contentStart, contentEnd);
-
-    // <code> keeps its content verbatim, like a backtick code span.
-    if (name == 'code') {
-      return _HtmlParseResult(
-        nodes: [InlineCodeNode(inner)],
-        consumed: consumed,
-      );
-    }
-
-    final children = parse(inner, depth: depth + 1);
-    final node = _buildHtmlInlineNode(name, tag.attributes, children);
-
-    // Unknown tags (and spans without usable styles) are stripped:
-    // their children are spliced into the surrounding content.
-    return _HtmlParseResult(
-      nodes: node != null ? [node] : children,
-      consumed: consumed,
-    );
-  }
-
-  /// Maps a whitelisted inline HTML tag to its AST node.
-  ///
-  /// Returns `null` for unknown tags and for `a`/`span`/`font` tags
-  /// without usable attributes, which callers treat as "strip the tag
-  /// and keep the children".
-  MarkdownNode? _buildHtmlInlineNode(
-    String name,
-    Map<String, String> attributes,
-    List<MarkdownNode> children,
-  ) {
-    switch (name) {
-      case 'b':
-      case 'strong':
-        return BoldNode(children);
-      case 'i':
-      case 'em':
-        return ItalicNode(children);
-      case 's':
-      case 'del':
-      case 'strike':
-        return StrikethroughNode(children);
-      case 'u':
-      case 'ins':
-        return UnderlineNode(children);
-      case 'mark':
-        return HighlightNode(children);
-      case 'sub':
-        return SubscriptNode(children);
-      case 'sup':
-        return SuperscriptNode(children);
-      case 'kbd':
-        return KbdNode(children);
-      case 'a':
-        return _buildHtmlLinkNode(attributes, children);
-      case 'font':
-      case 'span':
-        return _buildStyledSpanNode(name, attributes, children);
-      default:
-        return null;
-    }
-  }
-
-  /// Builds a [LinkNode] from `<a>` attributes.
-  ///
-  /// Returns `null` (strip tag, keep children) when the `href` is
-  /// missing, empty, or uses an unsafe scheme.
-  MarkdownNode? _buildHtmlLinkNode(
-    Map<String, String> attributes,
-    List<MarkdownNode> children,
-  ) {
-    final href = attributes['href'];
-    if (href == null || href.isEmpty || !isSafeHtmlUrl(href)) {
-      return null;
-    }
-    final title = attributes['title'];
-    return LinkNode(
-      url: href,
-      children: children,
-      title: title == null || title.isEmpty ? null : title,
-    );
-  }
-
-  /// Builds a [StyledSpanNode] from `<font>` attributes or a `<span>`
-  /// `style` attribute.
-  ///
-  /// Only the safe subset (color, background color, font size) is
-  /// honored; all other styling is ignored. Returns `null` when no
-  /// usable style remains.
-  MarkdownNode? _buildStyledSpanNode(
-    String name,
-    Map<String, String> attributes,
-    List<MarkdownNode> children,
-  ) {
-    int? color;
-    int? backgroundColor;
-    double? fontSize;
-
-    if (name == 'font') {
-      final colorAttr = attributes['color'];
-      if (colorAttr != null) {
-        color = parseHtmlColor(colorAttr);
-      }
-      final sizeAttr = attributes['size'];
-      if (sizeAttr != null) {
-        fontSize = parseFontSizeAttr(sizeAttr);
-      }
-    } else {
-      final style = attributes['style'];
-      if (style != null) {
-        final declarations = parseInlineCssDeclarations(style);
-        final colorValue = declarations['color'];
-        if (colorValue != null) {
-          color = parseHtmlColor(colorValue);
-        }
-        final backgroundValue = declarations['background-color'];
-        if (backgroundValue != null) {
-          backgroundColor = parseHtmlColor(backgroundValue);
-        }
-        final sizeValue = declarations['font-size'];
-        if (sizeValue != null) {
-          fontSize = parseHtmlFontSize(sizeValue);
-        }
-      }
-    }
-
-    if (color == null && backgroundColor == null && fontSize == null) {
-      return null;
-    }
-    return StyledSpanNode(
-      children: children,
-      color: color,
-      backgroundColor: backgroundColor,
-      fontSize: fontSize,
-    );
-  }
-
-  /// Builds the nodes for an `<img>` tag.
-  ///
-  /// An unsafe or missing `src` degrades to the alt text (or nothing).
-  List<MarkdownNode> _buildHtmlImageNodes(HtmlTag tag) {
-    final src = tag.attributes['src'] ?? '';
-    final alt = tag.attributes['alt'] ?? '';
-    if (src.isEmpty || !isSafeHtmlUrl(src)) {
-      return alt.isEmpty ? const [] : [TextNode(alt)];
-    }
-    final title = tag.attributes['title'];
-    final width = tag.attributes['width'];
-    final height = tag.attributes['height'];
-    return [
-      ImageNode(
-        url: src,
-        alt: alt,
-        title: title == null || title.isEmpty ? null : title,
-        width: width == null ? null : parseHtmlDimension(width),
-        height: height == null ? null : parseHtmlDimension(height),
-      ),
-    ];
-  }
-
   /// Merges consecutive TextNode instances
   List<MarkdownNode> _mergeTextNodes(List<MarkdownNode> nodes) {
     if (nodes.isEmpty) return nodes;
@@ -879,17 +676,6 @@ class _InlineParseResult {
   });
 
   final MarkdownNode node;
-  final int consumed;
-}
-
-/// Result of parsing an HTML tag, which may yield zero or more nodes
-class _HtmlParseResult {
-  const _HtmlParseResult({
-    required this.nodes,
-    required this.consumed,
-  });
-
-  final List<MarkdownNode> nodes;
   final int consumed;
 }
 

--- a/lib/src/parser/inline_parser.dart
+++ b/lib/src/parser/inline_parser.dart
@@ -114,7 +114,10 @@ class InlineParser {
 
       // Try HTML tag (may yield zero or several nodes, so it bypasses
       // the single-node flow and continues the loop directly)
-      if (node == null && _enableHtml && text[i] == '<') {
+      if (node == null &&
+          _enableHtml &&
+          text[i] == '<' &&
+          _canStartHtmlTag(text, i)) {
         final result = _tryParseHtmlTag(text, i, depth);
         if (result != null) {
           assert(result.consumed > 0, 'HTML parsing must consume input');
@@ -544,45 +547,73 @@ class InlineParser {
   }
 
   /// Consumes plain text until a special character
+  ///
+  /// Scans with code units and returns a single substring instead of
+  /// building the run character by character — this is the hottest
+  /// loop in the parser.
   _PlainTextResult _consumePlainText(String text, int start) {
-    final buffer = StringBuffer();
+    final plugins = _plugins;
     var i = start;
 
     while (i < text.length) {
-      final char = text[i];
+      final code = text.codeUnitAt(i);
 
-      if (char == ' ' && _tryParseHardBreak(text, i) != null) {
+      // Stop at special characters (including backslash for escape
+      // handling): \ * _ ` ~ [ ! $
+      if (code == 0x5C ||
+          code == 0x2A ||
+          code == 0x5F ||
+          code == 0x60 ||
+          code == 0x7E ||
+          code == 0x5B ||
+          code == 0x21 ||
+          code == 0x24) {
         break;
       }
 
-      // Stop at special characters (including backslash for escape handling)
-      if (char == r'\' ||
-          char == '*' ||
-          char == '_' ||
-          char == '`' ||
-          char == '~' ||
-          char == '[' ||
-          char == '!' ||
-          char == '\$' ||
-          (_enableHtml && char == '<')) {
+      // Stop at `<` only when it can actually start an HTML tag, so
+      // plain-text uses like `a < b` stay inside this fast path.
+      if (code == 0x3C && _enableHtml && _canStartHtmlTag(text, i)) {
+        break;
+      }
+
+      // Stop at a potential hard line break.
+      if (code == 0x20 && _tryParseHardBreak(text, i) != null) {
         break;
       }
 
       // Stop at plugin trigger characters
-      final plugins = _plugins;
-      if (plugins != null && plugins.isInlineTrigger(char)) {
+      if (plugins != null && plugins.isInlineTrigger(text[i])) {
         break;
       }
 
-      buffer.write(char);
       i++;
     }
 
-    final result = buffer.toString();
+    if (i == start) {
+      // The first character is itself a stop character that no parser
+      // consumed; emit it as a single literal character.
+      return _PlainTextResult(text: text[start], length: 1);
+    }
     return _PlainTextResult(
-      text: result.isEmpty ? text[start] : result,
-      length: result.isEmpty ? 1 : result.length,
+      text: text.substring(start, i),
+      length: i - start,
     );
+  }
+
+  /// Whether the character after the `<` at [index] can start a tag.
+  ///
+  /// Cheap pre-filter shared by the parse loop and the plain-text
+  /// scanner: only an ASCII letter (open tag) or `/` (closing tag) may
+  /// follow `<`, so text like `a < b`, `2<3`, or a trailing `<` never
+  /// fragments the text run nor invokes the tag lexer.
+  static bool _canStartHtmlTag(String text, int index) {
+    final next = index + 1;
+    if (next >= text.length) return false;
+    final code = text.codeUnitAt(next);
+    return (code >= 0x41 && code <= 0x5A) ||
+        (code >= 0x61 && code <= 0x7A) ||
+        code == 0x2F;
   }
 
   /// Tries to parse using registered plugins

--- a/lib/src/parser/inline_parser.dart
+++ b/lib/src/parser/inline_parser.dart
@@ -648,7 +648,7 @@ class InlineParser {
     // Paired tag: find the matching close with a same-name counter.
     // A missing close tag auto-closes at the end of the text.
     final contentStart = tag.end;
-    final close = _findHtmlCloseTag(text, contentStart, name);
+    final close = findHtmlCloseTag(text, contentStart, name);
     final contentEnd = close?.start ?? text.length;
     final consumed = (close?.end ?? text.length) - start;
     final inner = text.substring(contentStart, contentEnd);
@@ -670,39 +670,6 @@ class InlineParser {
       nodes: node != null ? [node] : children,
       consumed: consumed,
     );
-  }
-
-  /// Finds the closing tag matching an open [name] tag.
-  ///
-  /// [from] is the index right after the open tag. Uses a same-name
-  /// counter so nested tags of the same name close at matching depth.
-  /// Returns `null` when no matching close tag exists.
-  _HtmlCloseTag? _findHtmlCloseTag(String text, int from, String name) {
-    var nesting = 1;
-    var i = from;
-    while (i < text.length) {
-      if (text[i] != '<') {
-        i++;
-        continue;
-      }
-      final tag = lexHtmlTag(text, i);
-      if (tag == null) {
-        i++;
-        continue;
-      }
-      if (tag.name == name) {
-        if (tag.isClosing) {
-          nesting--;
-          if (nesting == 0) {
-            return _HtmlCloseTag(start: i, end: tag.end);
-          }
-        } else if (!tag.isSelfClosing) {
-          nesting++;
-        }
-      }
-      i = tag.end;
-    }
-    return null;
   }
 
   /// Maps a whitelisted inline HTML tag to its AST node.
@@ -892,20 +859,6 @@ class _HtmlParseResult {
 
   final List<MarkdownNode> nodes;
   final int consumed;
-}
-
-/// Location of a matching HTML closing tag
-class _HtmlCloseTag {
-  const _HtmlCloseTag({
-    required this.start,
-    required this.end,
-  });
-
-  /// Index of the `<` of the closing tag
-  final int start;
-
-  /// Index just past the `>` of the closing tag
-  final int end;
 }
 
 /// URL and optional title

--- a/lib/src/parser/markdown_parser.dart
+++ b/lib/src/parser/markdown_parser.dart
@@ -1,3 +1,4 @@
+import 'ast/html_nodes.dart';
 import 'ast/markdown_node.dart';
 import 'block_parser.dart';
 import 'inline_parser.dart';
@@ -33,10 +34,12 @@ class MarkdownParser {
   /// Creates a new Markdown parser
   ///
   /// Optionally accepts a [ParserPluginRegistry] for custom syntax plugins.
-  MarkdownParser({ParserPluginRegistry? plugins})
+  /// When [enableHtml] is true, whitelisted HTML tags and blocks are
+  /// parsed; it is disabled by default for security.
+  MarkdownParser({ParserPluginRegistry? plugins, bool enableHtml = false})
       : _plugins = plugins,
-        _blockParser = BlockParser(plugins: plugins),
-        _inlineParser = InlineParser(plugins: plugins);
+        _blockParser = BlockParser(plugins: plugins, enableHtml: enableHtml),
+        _inlineParser = InlineParser(plugins: plugins, enableHtml: enableHtml);
 
   final BlockParser _blockParser;
   final InlineParser _inlineParser;
@@ -86,10 +89,18 @@ class MarkdownParser {
       return _processList(node);
     } else if (node is ListItemNode) {
       return _processListItem(node);
+    } else if (node is HtmlBlockNode) {
+      return _processHtmlBlock(node);
     } else {
       // Other nodes (CodeBlock, HorizontalRule, Image, etc.) don't need inline processing
       return node;
     }
+  }
+
+  /// Processes inline elements in an HTML block's children
+  HtmlBlockNode _processHtmlBlock(HtmlBlockNode node) {
+    final newChildren = node.children.map(_processInlineElements).toList();
+    return node.copyWith(children: newChildren);
   }
 
   /// Processes inline elements in header content

--- a/lib/src/parser/markdown_parser.dart
+++ b/lib/src/parser/markdown_parser.dart
@@ -91,6 +91,8 @@ class MarkdownParser {
       return _processListItem(node);
     } else if (node is HtmlBlockNode) {
       return _processHtmlBlock(node);
+    } else if (node is DetailsNode) {
+      return _processDetails(node);
     } else {
       // Other nodes (CodeBlock, HorizontalRule, Image, etc.) don't need inline processing
       return node;
@@ -99,6 +101,15 @@ class MarkdownParser {
 
   /// Processes inline elements in an HTML block's children
   HtmlBlockNode _processHtmlBlock(HtmlBlockNode node) {
+    final newChildren = node.children.map(_processInlineElements).toList();
+    return node.copyWith(children: newChildren);
+  }
+
+  /// Processes inline elements in a details block's children
+  ///
+  /// The summary is already inline-parsed by the block parser, so only
+  /// the body content needs recursive processing.
+  DetailsNode _processDetails(DetailsNode node) {
     final newChildren = node.children.map(_processInlineElements).toList();
     return node.copyWith(children: newChildren);
   }

--- a/lib/src/renderer/builders/html_block_builder.dart
+++ b/lib/src/renderer/builders/html_block_builder.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/widgets.dart';
+
+import '../../config/style_sheet.dart';
+import '../../parser/ast/html_nodes.dart';
+import '../../parser/ast/markdown_node.dart';
+import '../widget_builder.dart';
+
+/// Builder for HTML block nodes (`<div>`, `<p>`, `<center>`)
+///
+/// Renders the block children through the regular block renderer and
+/// applies the `align` attribute. Alignment positions the block's
+/// content as a whole (the renderer's outer column is stretched, so
+/// alignment has to happen here); it does not re-align individual text
+/// lines within wrapped paragraphs.
+class HtmlBlockBuilder extends MarkdownWidgetBuilder {
+  /// Creates a new HTML block builder
+  const HtmlBlockBuilder();
+
+  @override
+  bool canBuild(MarkdownNode node) => node is HtmlBlockNode;
+
+  @override
+  Widget build(
+    MarkdownNode node,
+    MarkdownStyleSheet styleSheet,
+    MarkdownRenderContext context,
+  ) {
+    final blockNode = node as HtmlBlockNode;
+    final blockRenderer = context.blockRenderer;
+
+    final content = blockRenderer != null
+        ? blockRenderer(blockNode.children)
+        : Text(_extractText(blockNode.children), style: styleSheet.textStyle);
+
+    return switch (blockNode.align) {
+      null || HtmlBlockAlignment.left => content,
+      HtmlBlockAlignment.center => Align(
+          child: IntrinsicWidth(child: content),
+        ),
+      HtmlBlockAlignment.right => Align(
+          alignment: Alignment.centerRight,
+          child: IntrinsicWidth(child: content),
+        ),
+    };
+  }
+
+  String _extractText(List<MarkdownNode> nodes) {
+    return nodes.whereType<TextNode>().map((n) => n.content).join();
+  }
+}

--- a/lib/src/renderer/builders/html_block_builder.dart
+++ b/lib/src/renderer/builders/html_block_builder.dart
@@ -30,7 +30,8 @@ class HtmlBlockBuilder extends MarkdownWidgetBuilder {
 
     final content = blockRenderer != null
         ? blockRenderer(blockNode.children)
-        : Text(_extractText(blockNode.children), style: styleSheet.textStyle);
+        : Text(extractPlainText(blockNode.children),
+            style: styleSheet.textStyle);
 
     return switch (blockNode.align) {
       null || HtmlBlockAlignment.left => content,
@@ -42,9 +43,5 @@ class HtmlBlockBuilder extends MarkdownWidgetBuilder {
           child: IntrinsicWidth(child: content),
         ),
     };
-  }
-
-  String _extractText(List<MarkdownNode> nodes) {
-    return nodes.whereType<TextNode>().map((n) => n.content).join();
   }
 }

--- a/lib/src/renderer/builders/html_block_builder.dart
+++ b/lib/src/renderer/builders/html_block_builder.dart
@@ -26,6 +26,7 @@ class HtmlBlockBuilder extends MarkdownWidgetBuilder {
     MarkdownRenderContext context,
   ) {
     final blockNode = node as HtmlBlockNode;
+    final contextualRenderer = context.contextualBlockRenderer;
     final blockRenderer = context.blockRenderer;
 
     // Alignment is applied as text-level alignment rather than by shrink-
@@ -39,13 +40,17 @@ class HtmlBlockBuilder extends MarkdownWidgetBuilder {
       null || HtmlBlockAlignment.left => null,
     };
 
+    if (contextualRenderer != null) {
+      return contextualRenderer(
+        blockNode.children,
+        context: textAlign == null
+            ? null
+            : context.copyWith(textAlign: textAlign),
+      );
+    }
+
     if (blockRenderer != null) {
-      return textAlign == null
-          ? blockRenderer(blockNode.children)
-          : blockRenderer(
-              blockNode.children,
-              context: context.copyWith(textAlign: textAlign),
-            );
+      return blockRenderer(blockNode.children);
     }
 
     return Text(

--- a/lib/src/renderer/builders/html_block_builder.dart
+++ b/lib/src/renderer/builders/html_block_builder.dart
@@ -28,20 +28,30 @@ class HtmlBlockBuilder extends MarkdownWidgetBuilder {
     final blockNode = node as HtmlBlockNode;
     final blockRenderer = context.blockRenderer;
 
-    final content = blockRenderer != null
-        ? blockRenderer(blockNode.children)
-        : Text(extractPlainText(blockNode.children),
-            style: styleSheet.textStyle);
-
-    return switch (blockNode.align) {
-      null || HtmlBlockAlignment.left => content,
-      HtmlBlockAlignment.center => Align(
-          child: IntrinsicWidth(child: content),
-        ),
-      HtmlBlockAlignment.right => Align(
-          alignment: Alignment.centerRight,
-          child: IntrinsicWidth(child: content),
-        ),
+    // Alignment is applied as text-level alignment rather than by shrink-
+    // wrapping the block. IntrinsicWidth would recompute the block width on
+    // every streaming update (horizontal jitter) and force an expensive
+    // intrinsic layout pass; textAlign reflows smoothly and matches browser
+    // behavior for `<center>` and `align`.
+    final textAlign = switch (blockNode.align) {
+      HtmlBlockAlignment.center => TextAlign.center,
+      HtmlBlockAlignment.right => TextAlign.right,
+      null || HtmlBlockAlignment.left => null,
     };
+
+    if (blockRenderer != null) {
+      return textAlign == null
+          ? blockRenderer(blockNode.children)
+          : blockRenderer(
+              blockNode.children,
+              context: context.copyWith(textAlign: textAlign),
+            );
+    }
+
+    return Text(
+      extractPlainText(blockNode.children),
+      style: styleSheet.textStyle,
+      textAlign: textAlign,
+    );
   }
 }

--- a/lib/src/renderer/builders/html_inline_builder.dart
+++ b/lib/src/renderer/builders/html_inline_builder.dart
@@ -15,10 +15,6 @@ const double _subscriptShiftFactor = 0.15;
 /// Fallback border color for `<kbd>` keys
 const Color _kbdFallbackBorderColor = Color(0xFFBDBDBD);
 
-String _extractText(List<MarkdownNode> nodes) {
-  return nodes.whereType<TextNode>().map((n) => n.content).join();
-}
-
 double _baseFontSize(MarkdownStyleSheet styleSheet) {
   return styleSheet.textStyle?.fontSize ?? 16;
 }
@@ -41,14 +37,7 @@ class UnderlineBuilder extends MarkdownWidgetBuilder {
     final style = styleSheet.underlineStyle ??
         (styleSheet.textStyle ?? const TextStyle())
             .copyWith(decoration: TextDecoration.underline);
-    final inlineRenderer = context.inlineRenderer;
-
-    if (inlineRenderer != null) {
-      return inlineRenderer(underlineNode.children, style);
-    }
-
-    // Fallback
-    return Text(_extractText(underlineNode.children), style: style);
+    return renderInlineOrFallback(underlineNode.children, style, context);
   }
 }
 
@@ -70,14 +59,7 @@ class HighlightBuilder extends MarkdownWidgetBuilder {
     final style = styleSheet.highlightStyle ??
         (styleSheet.textStyle ?? const TextStyle())
             .copyWith(backgroundColor: const Color(0xFFFFF176));
-    final inlineRenderer = context.inlineRenderer;
-
-    if (inlineRenderer != null) {
-      return inlineRenderer(highlightNode.children, style);
-    }
-
-    // Fallback
-    return Text(_extractText(highlightNode.children), style: style);
+    return renderInlineOrFallback(highlightNode.children, style, context);
   }
 }
 
@@ -150,10 +132,7 @@ Widget _buildShiftedText({
   final effectiveStyle = style ??
       (styleSheet.textStyle ?? const TextStyle())
           .copyWith(fontSize: baseFontSize * _subSupFontScale);
-  final inlineRenderer = context.inlineRenderer;
-  final inner = inlineRenderer != null
-      ? inlineRenderer(children, effectiveStyle)
-      : Text(_extractText(children), style: effectiveStyle);
+  final inner = renderInlineOrFallback(children, effectiveStyle, context);
 
   return Transform.translate(
     offset: Offset(0, baseFontSize * shiftFactor),
@@ -189,7 +168,7 @@ class KbdBuilder extends MarkdownWidgetBuilder {
         borderRadius: BorderRadius.circular(4),
         color: borderColor.withValues(alpha: 0.12),
       ),
-      child: Text(_extractText(kbdNode.children), style: style),
+      child: Text(extractPlainText(kbdNode.children), style: style),
     );
   }
 }
@@ -220,13 +199,6 @@ class StyledSpanBuilder extends MarkdownWidgetBuilder {
       backgroundColor: backgroundValue == null ? null : Color(backgroundValue),
       fontSize: spanNode.fontSize,
     );
-    final inlineRenderer = context.inlineRenderer;
-
-    if (inlineRenderer != null) {
-      return inlineRenderer(spanNode.children, style);
-    }
-
-    // Fallback
-    return Text(_extractText(spanNode.children), style: style);
+    return renderInlineOrFallback(spanNode.children, style, context);
   }
 }

--- a/lib/src/renderer/builders/html_inline_builder.dart
+++ b/lib/src/renderer/builders/html_inline_builder.dart
@@ -5,9 +5,6 @@ import '../../parser/ast/html_nodes.dart';
 import '../../parser/ast/markdown_node.dart';
 import '../widget_builder.dart';
 
-/// Font scale applied to subscript and superscript text
-const double _subSupFontScale = 0.75;
-
 /// Vertical shift factors relative to the base font size
 const double _superscriptShiftFactor = -0.35;
 const double _subscriptShiftFactor = 0.15;
@@ -18,6 +15,12 @@ const Color _kbdFallbackBorderColor = Color(0xFFBDBDBD);
 double _baseFontSize(MarkdownStyleSheet styleSheet) {
   return styleSheet.textStyle?.fontSize ?? 16;
 }
+
+/// The base text style, defaulting to a plain [TextStyle] so HTML-specific
+/// decorations can layer onto inherited text styling when no explicit style
+/// is provided for an element.
+TextStyle _inheritedBase(MarkdownStyleSheet styleSheet) =>
+    styleSheet.textStyle ?? const TextStyle();
 
 /// Builder for underline nodes from HTML `<u>`/`<ins>` tags
 class UnderlineBuilder extends MarkdownWidgetBuilder {
@@ -35,7 +38,7 @@ class UnderlineBuilder extends MarkdownWidgetBuilder {
   ) {
     final underlineNode = node as UnderlineNode;
     final style = styleSheet.underlineStyle ??
-        (styleSheet.textStyle ?? const TextStyle())
+        _inheritedBase(styleSheet)
             .copyWith(decoration: TextDecoration.underline);
     return renderInlineOrFallback(underlineNode.children, style, context);
   }
@@ -57,7 +60,7 @@ class HighlightBuilder extends MarkdownWidgetBuilder {
   ) {
     final highlightNode = node as HighlightNode;
     final style = styleSheet.highlightStyle ??
-        (styleSheet.textStyle ?? const TextStyle())
+        _inheritedBase(styleSheet)
             .copyWith(backgroundColor: const Color(0xFFFFF176));
     return renderInlineOrFallback(highlightNode.children, style, context);
   }
@@ -130,8 +133,8 @@ Widget _buildShiftedText({
 }) {
   final baseFontSize = _baseFontSize(styleSheet);
   final effectiveStyle = style ??
-      (styleSheet.textStyle ?? const TextStyle())
-          .copyWith(fontSize: baseFontSize * _subSupFontScale);
+      _inheritedBase(styleSheet)
+          .copyWith(fontSize: baseFontSize * markdownSubSupFontScale);
   final inner = renderInlineOrFallback(children, effectiveStyle, context);
 
   return Transform.translate(
@@ -158,7 +161,7 @@ class KbdBuilder extends MarkdownWidgetBuilder {
     final borderColor =
         styleSheet.horizontalRuleColor ?? _kbdFallbackBorderColor;
     final style = styleSheet.kbdStyle ??
-        (styleSheet.textStyle ?? const TextStyle())
+        _inheritedBase(styleSheet)
             .copyWith(fontFamily: 'monospace', fontSize: 13);
 
     return Container(

--- a/lib/src/renderer/builders/html_inline_builder.dart
+++ b/lib/src/renderer/builders/html_inline_builder.dart
@@ -1,0 +1,232 @@
+import 'package:flutter/widgets.dart';
+
+import '../../config/style_sheet.dart';
+import '../../parser/ast/html_nodes.dart';
+import '../../parser/ast/markdown_node.dart';
+import '../widget_builder.dart';
+
+/// Font scale applied to subscript and superscript text
+const double _subSupFontScale = 0.75;
+
+/// Vertical shift factors relative to the base font size
+const double _superscriptShiftFactor = -0.35;
+const double _subscriptShiftFactor = 0.15;
+
+/// Fallback border color for `<kbd>` keys
+const Color _kbdFallbackBorderColor = Color(0xFFBDBDBD);
+
+String _extractText(List<MarkdownNode> nodes) {
+  return nodes.whereType<TextNode>().map((n) => n.content).join();
+}
+
+double _baseFontSize(MarkdownStyleSheet styleSheet) {
+  return styleSheet.textStyle?.fontSize ?? 16;
+}
+
+/// Builder for underline nodes from HTML `<u>`/`<ins>` tags
+class UnderlineBuilder extends MarkdownWidgetBuilder {
+  /// Creates a new underline builder
+  const UnderlineBuilder();
+
+  @override
+  bool canBuild(MarkdownNode node) => node is UnderlineNode;
+
+  @override
+  Widget build(
+    MarkdownNode node,
+    MarkdownStyleSheet styleSheet,
+    MarkdownRenderContext context,
+  ) {
+    final underlineNode = node as UnderlineNode;
+    final style = styleSheet.underlineStyle ??
+        (styleSheet.textStyle ?? const TextStyle())
+            .copyWith(decoration: TextDecoration.underline);
+    final inlineRenderer = context.inlineRenderer;
+
+    if (inlineRenderer != null) {
+      return inlineRenderer(underlineNode.children, style);
+    }
+
+    // Fallback
+    return Text(_extractText(underlineNode.children), style: style);
+  }
+}
+
+/// Builder for highlight nodes from the HTML `<mark>` tag
+class HighlightBuilder extends MarkdownWidgetBuilder {
+  /// Creates a new highlight builder
+  const HighlightBuilder();
+
+  @override
+  bool canBuild(MarkdownNode node) => node is HighlightNode;
+
+  @override
+  Widget build(
+    MarkdownNode node,
+    MarkdownStyleSheet styleSheet,
+    MarkdownRenderContext context,
+  ) {
+    final highlightNode = node as HighlightNode;
+    final style = styleSheet.highlightStyle ??
+        (styleSheet.textStyle ?? const TextStyle())
+            .copyWith(backgroundColor: const Color(0xFFFFF176));
+    final inlineRenderer = context.inlineRenderer;
+
+    if (inlineRenderer != null) {
+      return inlineRenderer(highlightNode.children, style);
+    }
+
+    // Fallback
+    return Text(_extractText(highlightNode.children), style: style);
+  }
+}
+
+/// Builder for subscript nodes from the HTML `<sub>` tag
+///
+/// Flutter has no native subscript text style, so the content is
+/// rendered smaller and shifted down with a paint-time transform,
+/// which keeps line layout unaffected.
+class SubscriptBuilder extends MarkdownWidgetBuilder {
+  /// Creates a new subscript builder
+  const SubscriptBuilder();
+
+  @override
+  bool canBuild(MarkdownNode node) => node is SubscriptNode;
+
+  @override
+  Widget build(
+    MarkdownNode node,
+    MarkdownStyleSheet styleSheet,
+    MarkdownRenderContext context,
+  ) {
+    final subscriptNode = node as SubscriptNode;
+    return _buildShiftedText(
+      children: subscriptNode.children,
+      styleSheet: styleSheet,
+      context: context,
+      style: styleSheet.subscriptStyle,
+      shiftFactor: _subscriptShiftFactor,
+    );
+  }
+}
+
+/// Builder for superscript nodes from the HTML `<sup>` tag
+///
+/// Flutter has no native superscript text style, so the content is
+/// rendered smaller and shifted up with a paint-time transform,
+/// which keeps line layout unaffected.
+class SuperscriptBuilder extends MarkdownWidgetBuilder {
+  /// Creates a new superscript builder
+  const SuperscriptBuilder();
+
+  @override
+  bool canBuild(MarkdownNode node) => node is SuperscriptNode;
+
+  @override
+  Widget build(
+    MarkdownNode node,
+    MarkdownStyleSheet styleSheet,
+    MarkdownRenderContext context,
+  ) {
+    final superscriptNode = node as SuperscriptNode;
+    return _buildShiftedText(
+      children: superscriptNode.children,
+      styleSheet: styleSheet,
+      context: context,
+      style: styleSheet.superscriptStyle,
+      shiftFactor: _superscriptShiftFactor,
+    );
+  }
+}
+
+Widget _buildShiftedText({
+  required List<MarkdownNode> children,
+  required MarkdownStyleSheet styleSheet,
+  required MarkdownRenderContext context,
+  required TextStyle? style,
+  required double shiftFactor,
+}) {
+  final baseFontSize = _baseFontSize(styleSheet);
+  final effectiveStyle = style ??
+      (styleSheet.textStyle ?? const TextStyle())
+          .copyWith(fontSize: baseFontSize * _subSupFontScale);
+  final inlineRenderer = context.inlineRenderer;
+  final inner = inlineRenderer != null
+      ? inlineRenderer(children, effectiveStyle)
+      : Text(_extractText(children), style: effectiveStyle);
+
+  return Transform.translate(
+    offset: Offset(0, baseFontSize * shiftFactor),
+    child: inner,
+  );
+}
+
+/// Builder for keyboard input nodes from the HTML `<kbd>` tag
+class KbdBuilder extends MarkdownWidgetBuilder {
+  /// Creates a new keyboard input builder
+  const KbdBuilder();
+
+  @override
+  bool canBuild(MarkdownNode node) => node is KbdNode;
+
+  @override
+  Widget build(
+    MarkdownNode node,
+    MarkdownStyleSheet styleSheet,
+    MarkdownRenderContext context,
+  ) {
+    final kbdNode = node as KbdNode;
+    final borderColor =
+        styleSheet.horizontalRuleColor ?? _kbdFallbackBorderColor;
+    final style = styleSheet.kbdStyle ??
+        (styleSheet.textStyle ?? const TextStyle())
+            .copyWith(fontFamily: 'monospace', fontSize: 13);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
+      decoration: BoxDecoration(
+        border: Border.all(color: borderColor),
+        borderRadius: BorderRadius.circular(4),
+        color: borderColor.withValues(alpha: 0.12),
+      ),
+      child: Text(_extractText(kbdNode.children), style: style),
+    );
+  }
+}
+
+/// Builder for styled span nodes from HTML `<font>`/`<span>` tags
+///
+/// Builds a sparse [TextStyle] with only the parsed properties set, so
+/// unset properties inherit from the surrounding text through normal
+/// [TextSpan] style inheritance.
+class StyledSpanBuilder extends MarkdownWidgetBuilder {
+  /// Creates a new styled span builder
+  const StyledSpanBuilder();
+
+  @override
+  bool canBuild(MarkdownNode node) => node is StyledSpanNode;
+
+  @override
+  Widget build(
+    MarkdownNode node,
+    MarkdownStyleSheet styleSheet,
+    MarkdownRenderContext context,
+  ) {
+    final spanNode = node as StyledSpanNode;
+    final colorValue = spanNode.color;
+    final backgroundValue = spanNode.backgroundColor;
+    final style = TextStyle(
+      color: colorValue == null ? null : Color(colorValue),
+      backgroundColor: backgroundValue == null ? null : Color(backgroundValue),
+      fontSize: spanNode.fontSize,
+    );
+    final inlineRenderer = context.inlineRenderer;
+
+    if (inlineRenderer != null) {
+      return inlineRenderer(spanNode.children, style);
+    }
+
+    // Fallback
+    return Text(_extractText(spanNode.children), style: style);
+  }
+}

--- a/lib/src/renderer/builders/image_builder.dart
+++ b/lib/src/renderer/builders/image_builder.dart
@@ -87,12 +87,20 @@ class ImageBuilder extends MarkdownWidgetBuilder {
     ImageNode imageNode,
     Widget child,
   ) {
+    // Apply explicit dimensions from HTML <img width/height> attributes.
+    var sizedChild = child;
+    if (imageNode.width != null || imageNode.height != null) {
+      sizedChild = SizedBox(
+        width: imageNode.width,
+        height: imageNode.height,
+        child: child,
+      );
+    }
     final semanticChild = Semantics(
       image: true,
-      label: imageNode.alt.isNotEmpty
-          ? imageNode.alt
-          : imageNode.title ?? 'Image',
-      child: child,
+      label:
+          imageNode.alt.isNotEmpty ? imageNode.alt : imageNode.title ?? 'Image',
+      child: sizedChild,
     );
     final onTap = context.onTapImage;
     if (onTap == null) return semanticChild;

--- a/lib/src/renderer/builders/text_style_builder.dart
+++ b/lib/src/renderer/builders/text_style_builder.dart
@@ -19,18 +19,11 @@ class BoldBuilder extends MarkdownWidgetBuilder {
     MarkdownRenderContext context,
   ) {
     final boldNode = node as BoldNode;
-    final inlineRenderer = context.inlineRenderer;
-
-    if (inlineRenderer != null) {
-      return inlineRenderer(boldNode.children, styleSheet.boldStyle);
-    }
-
-    // Fallback
-    return Text(_extractText(boldNode.children), style: styleSheet.boldStyle);
-  }
-
-  String _extractText(List<MarkdownNode> nodes) {
-    return nodes.whereType<TextNode>().map((n) => n.content).join();
+    return renderInlineOrFallback(
+      boldNode.children,
+      styleSheet.boldStyle,
+      context,
+    );
   }
 }
 
@@ -49,18 +42,11 @@ class ItalicBuilder extends MarkdownWidgetBuilder {
     MarkdownRenderContext context,
   ) {
     final italicNode = node as ItalicNode;
-    final inlineRenderer = context.inlineRenderer;
-
-    if (inlineRenderer != null) {
-      return inlineRenderer(italicNode.children, styleSheet.italicStyle);
-    }
-
-    // Fallback
-    return Text(_extractText(italicNode.children), style: styleSheet.italicStyle);
-  }
-
-  String _extractText(List<MarkdownNode> nodes) {
-    return nodes.whereType<TextNode>().map((n) => n.content).join();
+    return renderInlineOrFallback(
+      italicNode.children,
+      styleSheet.italicStyle,
+      context,
+    );
   }
 }
 
@@ -79,17 +65,10 @@ class StrikethroughBuilder extends MarkdownWidgetBuilder {
     MarkdownRenderContext context,
   ) {
     final strikeNode = node as StrikethroughNode;
-    final inlineRenderer = context.inlineRenderer;
-
-    if (inlineRenderer != null) {
-      return inlineRenderer(strikeNode.children, styleSheet.strikethroughStyle);
-    }
-
-    // Fallback
-    return Text(_extractText(strikeNode.children), style: styleSheet.strikethroughStyle);
-  }
-
-  String _extractText(List<MarkdownNode> nodes) {
-    return nodes.whereType<TextNode>().map((n) => n.content).join();
+    return renderInlineOrFallback(
+      strikeNode.children,
+      styleSheet.strikethroughStyle,
+      context,
+    );
   }
 }

--- a/lib/src/renderer/markdown_renderer.dart
+++ b/lib/src/renderer/markdown_renderer.dart
@@ -151,7 +151,8 @@ class MarkdownRenderer {
     final renderContext = baseContext.copyWith(
       inlineRenderer: (childNodes, baseStyle) =>
           renderInline(childNodes, baseStyle, baseContext),
-      blockRenderer: (childNodes) => render(childNodes, context: baseContext),
+      blockRenderer: (childNodes, {context}) =>
+          render(childNodes, context: context ?? baseContext),
       styleSheet: styleSheet,
     );
 
@@ -322,6 +323,7 @@ class MarkdownRenderer {
           style: baseStyle,
           children: spans,
         ),
+        textAlign: context.textAlign,
       );
     }
 
@@ -330,6 +332,7 @@ class MarkdownRenderer {
         style: baseStyle,
         children: spans,
       ),
+      textAlign: context.textAlign ?? TextAlign.start,
     );
   }
 

--- a/lib/src/renderer/markdown_renderer.dart
+++ b/lib/src/renderer/markdown_renderer.dart
@@ -148,11 +148,22 @@ class MarkdownRenderer {
   }) {
     // Create context with renderer references for nested rendering
     final baseContext = context ?? const MarkdownRenderContext();
+    // A single context-aware closure renders child blocks and (optionally)
+    // overrides the context. It is exposed twice so that builders can use it
+    // without a context (through [BlockRenderer], which keeps single-argument
+    // callbacks assignable) and *with* a context override (through
+    // [ContextualBlockRenderer], e.g. the HTML block applying text alignment).
+    Widget renderChildren(
+      List<MarkdownNode> childNodes, {
+      MarkdownRenderContext? context,
+    }) =>
+        render(childNodes, context: context ?? baseContext);
+
     final renderContext = baseContext.copyWith(
       inlineRenderer: (childNodes, baseStyle) =>
           renderInline(childNodes, baseStyle, baseContext),
-      blockRenderer: (childNodes, {context}) =>
-          render(childNodes, context: context ?? baseContext),
+      blockRenderer: renderChildren,
+      contextualBlockRenderer: renderChildren,
       styleSheet: styleSheet,
     );
 

--- a/lib/src/renderer/widget_builder.dart
+++ b/lib/src/renderer/widget_builder.dart
@@ -11,6 +11,8 @@ import 'builders/footnote_reference_builder.dart';
 import 'builders/hard_break_builder.dart';
 import 'builders/header_builder.dart';
 import 'builders/horizontal_rule_builder.dart';
+import 'builders/html_block_builder.dart';
+import 'builders/html_inline_builder.dart';
 import 'builders/image_builder.dart';
 import 'builders/inline_code_builder.dart';
 import 'builders/inline_math_builder.dart';
@@ -161,6 +163,13 @@ class BuilderRegistry {
       ..register('bold', const BoldBuilder())
       ..register('italic', const ItalicBuilder())
       ..register('strikethrough', const StrikethroughBuilder())
+      ..register('underline', const UnderlineBuilder())
+      ..register('highlight', const HighlightBuilder())
+      ..register('subscript', const SubscriptBuilder())
+      ..register('superscript', const SuperscriptBuilder())
+      ..register('kbd', const KbdBuilder())
+      ..register('styled_span', const StyledSpanBuilder())
+      ..register('html_block', const HtmlBlockBuilder())
       ..register('link', const LinkBuilder())
       ..register('image', const ImageBuilder());
   }

--- a/lib/src/renderer/widget_builder.dart
+++ b/lib/src/renderer/widget_builder.dart
@@ -34,6 +34,30 @@ typedef BlockRenderer = Widget Function(
   List<MarkdownNode> nodes,
 );
 
+/// Extracts plain text from a list of nodes by joining [TextNode] content.
+///
+/// Used as a fallback when no inline/block renderer is available, so the
+/// content is still readable instead of rendering nothing.
+String extractPlainText(List<MarkdownNode> nodes) {
+  return nodes.whereType<TextNode>().map((n) => n.content).join();
+}
+
+/// Renders [children] via the inline renderer when available, otherwise
+/// falls back to a flat [Text] widget built from [extractPlainText].
+///
+/// Shared by inline-style builders (bold, italic, underline, etc.) so the
+/// null-check dispatch lives in one place.
+Widget renderInlineOrFallback(
+  List<MarkdownNode> children,
+  TextStyle? style,
+  MarkdownRenderContext context,
+) {
+  final inlineRenderer = context.inlineRenderer;
+  return inlineRenderer != null
+      ? inlineRenderer(children, style)
+      : Text(extractPlainText(children), style: style);
+}
+
 /// Base class for building widgets from Markdown nodes
 ///
 /// Each type of Markdown element (header, paragraph, list, etc.)

--- a/lib/src/renderer/widget_builder.dart
+++ b/lib/src/renderer/widget_builder.dart
@@ -29,12 +29,35 @@ typedef InlineRenderer = Widget Function(
   TextStyle? baseStyle,
 );
 
-/// Function type for rendering block-level nodes
+/// Function type for rendering block-level nodes.
 ///
-/// The optional [MarkdownRenderContext] lets a caller (for example an HTML
-/// block that applies text alignment) override context for the rendered
-/// children; when omitted the renderer uses its current context.
-typedef BlockRenderer = Widget Function(
+/// This is the public callback contract and is intentionally kept
+/// single-argument: a plain `(nodes) => widget` function is assignable here,
+/// so existing callbacks keep working. It deliberately carries no context
+/// parameter so that changes to the context model never become a
+/// source-breaking change for callers that only render children. Use
+/// [ContextualBlockRenderer] (via [MarkdownRenderContext.contextualBlockRenderer])
+/// when a builder needs to override the render context.
+typedef BlockRenderer = Widget Function(List<MarkdownNode> nodes);
+
+/// Context-aware variant of [BlockRenderer].
+///
+/// The renderer's internal closure implements this so that builders can
+/// override the [MarkdownRenderContext] for their rendered children (for
+/// example an HTML block that applies text alignment). That closure backs
+/// both typedefs: it matches [ContextualBlockRenderer] exactly, and because
+/// a function accepting an optional `context` is also assignable to the
+/// single-argument [BlockRenderer] (callers that omit `context` still
+/// work), the same closure can populate
+/// [MarkdownRenderContext.blockRenderer] as well.
+///
+/// This typedef is intentionally additive so the public [BlockRenderer]
+/// stays single-argument and existing `(nodes) => widget` callbacks remain
+/// assignable to it. The subtyping runs one direction only: a plain
+/// single-argument callback is *not* assignable to [ContextualBlockRenderer]
+/// (it could not honor a `context` override), which is why builders that
+/// need the override go through this typedef rather than [BlockRenderer].
+typedef ContextualBlockRenderer = Widget Function(
   List<MarkdownNode> nodes, {
   MarkdownRenderContext? context,
 });
@@ -100,6 +123,7 @@ class MarkdownRenderContext {
     this.listLevel = 0,
     this.inlineRenderer,
     this.blockRenderer,
+    this.contextualBlockRenderer,
     this.styleSheet,
     this.selectable = false,
     this.textAlign,
@@ -126,11 +150,23 @@ class MarkdownRenderContext {
   /// renderer instance, preserving custom builder registrations.
   final InlineRenderer? inlineRenderer;
 
-  /// Block renderer function for rendering block-level child nodes
+  /// Block renderer function for rendering block-level child nodes.
   ///
   /// This allows builders to render block content (like blockquote children)
-  /// using the same renderer instance, preserving custom builder registrations.
+  /// using the same renderer instance, preserving custom builder
+  /// registrations. The contract is a plain single-argument
+  /// `(nodes) => widget` function so existing callbacks remain assignable.
   final BlockRenderer? blockRenderer;
+
+  /// Context-aware block renderer for rendering child blocks with a context
+  /// override.
+  ///
+  /// Set internally by the renderer. Builders that need to override the
+  /// context for their children (for example an HTML block applying text
+  /// alignment) call this with `context`; passing `null` renders with the
+  /// renderer's current context, exactly like [blockRenderer]. When unset,
+  /// fall back to [blockRenderer].
+  final ContextualBlockRenderer? contextualBlockRenderer;
 
   /// The style sheet being used for rendering
   final MarkdownStyleSheet? styleSheet;
@@ -158,6 +194,7 @@ class MarkdownRenderContext {
     int? listLevel,
     InlineRenderer? inlineRenderer,
     BlockRenderer? blockRenderer,
+    ContextualBlockRenderer? contextualBlockRenderer,
     MarkdownStyleSheet? styleSheet,
     bool? selectable,
     TextAlign? textAlign,
@@ -170,6 +207,8 @@ class MarkdownRenderContext {
       listLevel: listLevel ?? this.listLevel,
       inlineRenderer: inlineRenderer ?? this.inlineRenderer,
       blockRenderer: blockRenderer ?? this.blockRenderer,
+      contextualBlockRenderer:
+          contextualBlockRenderer ?? this.contextualBlockRenderer,
       styleSheet: styleSheet ?? this.styleSheet,
       selectable: selectable ?? this.selectable,
       textAlign: textAlign ?? this.textAlign,

--- a/lib/src/renderer/widget_builder.dart
+++ b/lib/src/renderer/widget_builder.dart
@@ -30,9 +30,14 @@ typedef InlineRenderer = Widget Function(
 );
 
 /// Function type for rendering block-level nodes
+///
+/// The optional [MarkdownRenderContext] lets a caller (for example an HTML
+/// block that applies text alignment) override context for the rendered
+/// children; when omitted the renderer uses its current context.
 typedef BlockRenderer = Widget Function(
-  List<MarkdownNode> nodes,
-);
+  List<MarkdownNode> nodes, {
+  MarkdownRenderContext? context,
+});
 
 /// Extracts plain text from a list of nodes by joining [TextNode] content.
 ///
@@ -97,6 +102,7 @@ class MarkdownRenderContext {
     this.blockRenderer,
     this.styleSheet,
     this.selectable = false,
+    this.textAlign,
   });
 
   /// Callback for link taps
@@ -135,6 +141,14 @@ class MarkdownRenderContext {
   /// to avoid nested selection conflicts.
   final bool selectable;
 
+  /// Text alignment applied to inline text rendered within this context.
+  ///
+  /// Used by HTML block builders (`<center>`, `align="right"`) so the
+  /// contained text is aligned at the text level rather than by shrink-
+  /// wrapping the block, which avoids layout reflow during streaming.
+  /// `null` leaves alignment at the default (start/left).
+  final TextAlign? textAlign;
+
   /// Creates a copy with updated fields
   MarkdownRenderContext copyWith({
     void Function(String url)? onTapLink,
@@ -146,6 +160,7 @@ class MarkdownRenderContext {
     BlockRenderer? blockRenderer,
     MarkdownStyleSheet? styleSheet,
     bool? selectable,
+    TextAlign? textAlign,
   }) {
     return MarkdownRenderContext(
       onTapLink: onTapLink ?? this.onTapLink,
@@ -157,6 +172,7 @@ class MarkdownRenderContext {
       blockRenderer: blockRenderer ?? this.blockRenderer,
       styleSheet: styleSheet ?? this.styleSheet,
       selectable: selectable ?? this.selectable,
+      textAlign: textAlign ?? this.textAlign,
     );
   }
 }

--- a/lib/widgets/smooth_markdown.dart
+++ b/lib/widgets/smooth_markdown.dart
@@ -661,7 +661,13 @@ class SmoothMarkdown extends StatelessWidget {
   final BuilderRegistry? builderRegistry;
 
   /// Global shared parse cache for all SmoothMarkdown instances
+  /// Global shared parse caches for all SmoothMarkdown instances.
+  ///
+  /// One cache per HTML config keeps results isolated between widgets
+  /// with different `enableHtml` settings without allocating a
+  /// prefixed key string (an O(n) copy of the document) on every build.
   static final _parseCache = MarkdownParseCache(maxSize: 100);
+  static final _htmlParseCache = MarkdownParseCache(maxSize: 100);
 
   @override
   Widget build(BuildContext context) {
@@ -672,18 +678,15 @@ class SmoothMarkdown extends StatelessWidget {
     // Parse markdown with optional caching
     // Note: When plugins are used, caching is based on data only.
     // If plugin configuration changes, you should disable caching.
-    // The cache key carries the enableHtml flag (NUL-delimited prefix,
-    // which cannot occur in real markdown) so results never leak
-    // across differently configured widgets.
-    final cacheKey = enableHtml ? '\u0000html\u0000$data' : data;
+    final cache = enableHtml ? _htmlParseCache : _parseCache;
     final List<MarkdownNode> nodes;
     if (enableCache && plugins == null) {
-      final cached = _parseCache.get(cacheKey);
+      final cached = cache.get(data);
       if (cached != null) {
         nodes = cached;
       } else {
         nodes = parser.parse(data);
-        _parseCache.put(cacheKey, nodes);
+        cache.put(data, nodes);
       }
     } else {
       nodes = parser.parse(data);
@@ -790,13 +793,14 @@ class SmoothMarkdown extends StatelessWidget {
   /// ```
   static void clearCache() {
     _parseCache.clear();
+    _htmlParseCache.clear();
   }
 
   /// Returns cache statistics for monitoring and tuning.
   ///
   /// Returns a map containing:
-  /// - `size`: Current number of cached entries
-  /// - `maxSize`: Maximum cache capacity
+  /// - `size`: Current number of cached entries (both configs)
+  /// - `maxSize`: Maximum cache capacity (both configs)
   /// - `utilization`: Cache utilization (0.0 to 1.0)
   ///
   /// Example:
@@ -805,7 +809,17 @@ class SmoothMarkdown extends StatelessWidget {
   /// final stats = SmoothMarkdown.cacheStatistics;
   /// print('Cache usage: ${stats['utilization'] * 100}%');
   /// ```
-  static Map<String, dynamic> get cacheStatistics => _parseCache.statistics;
+  static Map<String, dynamic> get cacheStatistics {
+    final base = _parseCache.statistics;
+    final html = _htmlParseCache.statistics;
+    final size = (base['size'] as int) + (html['size'] as int);
+    final maxSize = (base['maxSize'] as int) + (html['maxSize'] as int);
+    return {
+      'size': size,
+      'maxSize': maxSize,
+      'utilization': maxSize == 0 ? 0.0 : size / maxSize,
+    };
+  }
 
   /// Schedules a post-frame clipboard filter to remove overlay content.
   static void _scheduleClipboardFilter() {

--- a/lib/widgets/smooth_markdown.dart
+++ b/lib/widgets/smooth_markdown.dart
@@ -663,20 +663,25 @@ class SmoothMarkdown extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Create parser (with plugins if provided)
-    final parser = MarkdownParser(plugins: plugins);
+    // Create parser (with plugins and HTML support if configured)
+    final enableHtml = config?.enableHtml ?? false;
+    final parser = MarkdownParser(plugins: plugins, enableHtml: enableHtml);
 
     // Parse markdown with optional caching
     // Note: When plugins are used, caching is based on data only.
     // If plugin configuration changes, you should disable caching.
+    // The cache key carries the enableHtml flag (NUL-delimited prefix,
+    // which cannot occur in real markdown) so results never leak
+    // across differently configured widgets.
+    final cacheKey = enableHtml ? '\u0000html\u0000$data' : data;
     final List<MarkdownNode> nodes;
     if (enableCache && plugins == null) {
-      final cached = _parseCache.get(data);
+      final cached = _parseCache.get(cacheKey);
       if (cached != null) {
         nodes = cached;
       } else {
         nodes = parser.parse(data);
-        _parseCache.put(data, nodes);
+        _parseCache.put(cacheKey, nodes);
       }
     } else {
       nodes = parser.parse(data);

--- a/lib/widgets/smooth_markdown.dart
+++ b/lib/widgets/smooth_markdown.dart
@@ -660,7 +660,6 @@ class SmoothMarkdown extends StatelessWidget {
   /// Plugin builders take precedence.
   final BuilderRegistry? builderRegistry;
 
-  /// Global shared parse cache for all SmoothMarkdown instances
   /// Global shared parse caches for all SmoothMarkdown instances.
   ///
   /// One cache per HTML config keeps results isolated between widgets

--- a/lib/widgets/smooth_markdown.dart
+++ b/lib/widgets/smooth_markdown.dart
@@ -17,6 +17,8 @@ import '../src/renderer/builders/enhanced_link_builder.dart';
 import '../src/renderer/builders/footnote_definition_builder.dart';
 import '../src/renderer/builders/footnote_reference_builder.dart';
 import '../src/renderer/builders/horizontal_rule_builder.dart';
+import '../src/renderer/builders/html_block_builder.dart';
+import '../src/renderer/builders/html_inline_builder.dart';
 import '../src/renderer/builders/image_builder.dart';
 import '../src/renderer/builders/inline_code_builder.dart';
 import '../src/renderer/builders/inline_math_builder.dart';
@@ -704,6 +706,13 @@ class SmoothMarkdown extends StatelessWidget {
         ..register('bold', const BoldBuilder())
         ..register('italic', const ItalicBuilder())
         ..register('strikethrough', const StrikethroughBuilder())
+        ..register('underline', const UnderlineBuilder())
+        ..register('highlight', const HighlightBuilder())
+        ..register('subscript', const SubscriptBuilder())
+        ..register('superscript', const SuperscriptBuilder())
+        ..register('kbd', const KbdBuilder())
+        ..register('styled_span', const StyledSpanBuilder())
+        ..register('html_block', const HtmlBlockBuilder())
         ..register('image', const ImageBuilder())
         ..register('table', const TableBuilder())
         ..register('details', const DetailsBuilder())

--- a/lib/widgets/stream_markdown.dart
+++ b/lib/widgets/stream_markdown.dart
@@ -361,16 +361,52 @@ class _StreamMarkdownState extends State<StreamMarkdown> {
           _error = error;
         });
       },
+      onDone: () {
+        if (!mounted) return;
+        _throttleTimer?.cancel();
+        setState(() {
+          // Flush any withheld trailing tag now that the stream is complete.
+          _currentText = _buffer.toString();
+          _hasPendingUpdate = false;
+        });
+      },
     );
   }
 
   void _performUpdate() {
     if (!mounted) return;
     setState(() {
-      _currentText = _buffer.toString();
+      // Render up to the last complete tag boundary so a tag split across
+      // chunks (e.g. `<font colo` | `r="red">`) is not flashed as literal
+      // text. The withheld tail stays buffered and renders once its `>`
+      // arrives, or when the stream completes (see [onDone]).
+      _currentText = _safeRenderText(_buffer.toString());
       _lastUpdateTime = DateTime.now();
       _hasPendingUpdate = false;
     });
+  }
+
+  /// Returns the longest prefix of [full] that does not end inside an
+  /// unclosed HTML tag, so a partially-arrived tag is withheld from
+  /// rendering until it is complete.
+  ///
+  /// A literal `<` in prose (as in `a < b` or `<3`) is kept, because the
+  /// character following such a `<` is not an ASCII letter or `/` and so
+  /// cannot be the start of a tag.
+  static String _safeRenderText(String full) {
+    final lt = full.lastIndexOf('<');
+    if (lt < 0) return full;
+    // A '>' after the last '<' means the tag is already closed.
+    if (full.lastIndexOf('>') > lt) return full;
+    // Unclosed '<': withhold only when it starts a tag (a letter or '/').
+    if (lt + 1 < full.length) {
+      final next = full.codeUnitAt(lt + 1);
+      final isTagStart = (next >= 0x41 && next <= 0x5A) || // A-Z
+          (next >= 0x61 && next <= 0x7A) || // a-z
+          next == 0x2F; // '/'
+      if (!isTagStart) return full;
+    }
+    return full.substring(0, lt);
   }
 
   @override

--- a/lib/widgets/stream_markdown.dart
+++ b/lib/widgets/stream_markdown.dart
@@ -376,11 +376,20 @@ class _StreamMarkdownState extends State<StreamMarkdown> {
   void _performUpdate() {
     if (!mounted) return;
     setState(() {
-      // Render up to the last complete tag boundary so a tag split across
-      // chunks (e.g. `<font colo` | `r="red">`) is not flashed as literal
-      // text. The withheld tail stays buffered and renders once its `>`
-      // arrives, or when the stream completes (see [onDone]).
-      _currentText = _safeRenderText(_buffer.toString());
+      // Only withhold a partially-arrived HTML tag when HTML rendering is
+      // explicitly enabled. The withholding renders up to the last complete
+      // tag boundary so a tag split across chunks (e.g. `<font colo` |
+      // `r="red">`) is not flashed as literal text; the withheld tail stays
+      // buffered and renders once its `>` arrives, or when the stream
+      // completes (see [onDone]).
+      //
+      // When HTML is disabled (the default), sequences like `<font colo`, a
+      // trailing `<`, or `<` followed by letters are ordinary prose and must
+      // be rendered verbatim — withholding them would swallow streaming text.
+      final enableHtml = widget.config?.enableHtml ?? false;
+      _currentText = enableHtml
+          ? _safeRenderText(_buffer.toString())
+          : _buffer.toString();
       _lastUpdateTime = DateTime.now();
       _hasPendingUpdate = false;
     });
@@ -389,6 +398,11 @@ class _StreamMarkdownState extends State<StreamMarkdown> {
   /// Returns the longest prefix of [full] that does not end inside an
   /// unclosed HTML tag, so a partially-arrived tag is withheld from
   /// rendering until it is complete.
+  ///
+  /// This is only invoked when HTML rendering is enabled (see
+  /// [_performUpdate]); with HTML disabled, the buffer is rendered verbatim
+  /// so prose like `<font colo`, a trailing `<`, or `<` followed by letters
+  /// is never swallowed.
   ///
   /// A literal `<` in prose (as in `a < b` or `<3`) is kept, because the
   /// character following such a `<` is not an ASCII letter or `/` and so

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,24 +5,24 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "8d7ff3948166b8ec5da0fbb5962000926b8e02f2ed9b3e51d1738905fbd4c98d"
-      url: "https://pub.dev"
+      sha256: cd6add6f846f35fb79f3c315296703c1a24f3cfd7f4739d91a74961c1c7e9f1b
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "93.0.0"
+    version: "100.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: de7148ed2fcec579b19f122c1800933dfa028f6d9fd38a152b04b1516cec120b
-      url: "https://pub.dev"
+      sha256: "6ba98576948803398b69e3a444df24eacdbe12ed699c7014e120ea38552debbf"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "10.0.1"
+    version: "13.0.0"
   args:
     dependency: transitive
     description:
       name: args
       sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.7.0"
   async:
@@ -30,7 +30,7 @@ packages:
     description:
       name: async
       sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.13.1"
   boolean_selector:
@@ -38,47 +38,47 @@ packages:
     description:
       name: boolean_selector
       sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.2"
   build:
     dependency: transitive
     description:
       name: build
-      sha256: a156715e7cd728130c592f30552575908aae5b100005fbc1f0fb16b3c03a3d10
-      url: "https://pub.dev"
+      sha256: "45d14a0fb23e018d8287c32fc98d726ce466b231928ed9b9200f29bd3ccd39ae"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "4.0.6"
+    version: "4.0.7"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4070d2a59f8eec34c97c86ceb44403834899075f66e8a9d59706f8e7834f6f71"
-      url: "https://pub.dev"
+      sha256: f2c223156a26eea323e6244b85141d76413a80aeee9fe0b380773789fabaf8ae
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957
-      url: "https://pub.dev"
+      sha256: fd754058c342243718d5171a95f352cfc9fcf0cba8cfa26df67cb13a5836db78
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "4.1.1"
+    version: "4.1.2"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
-      url: "https://pub.dev"
+      sha256: "5367e521935b102bdf1e735d2aab461e36b2edca6517662d088dd04cc39f8d16"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.15.0"
+    version: "2.15.1"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
       sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "5.1.1"
   built_value:
@@ -86,7 +86,7 @@ packages:
     description:
       name: built_value
       sha256: "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "8.12.6"
   cached_network_image:
@@ -94,7 +94,7 @@ packages:
     description:
       name: cached_network_image
       sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.4.1"
   cached_network_image_platform_interface:
@@ -102,7 +102,7 @@ packages:
     description:
       name: cached_network_image_platform_interface
       sha256: "35814b016e37fbdc91f7ae18c8caf49ba5c88501813f73ce8a07027a395e2829"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "4.1.1"
   cached_network_image_web:
@@ -110,23 +110,23 @@ packages:
     description:
       name: cached_network_image_web
       sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.3.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
-      url: "https://pub.dev"
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
       sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.0.4"
   clock:
@@ -134,7 +134,7 @@ packages:
     description:
       name: clock
       sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.1.2"
   code_assets:
@@ -142,7 +142,7 @@ packages:
     description:
       name: code_assets
       sha256: bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.2.1"
   code_builder:
@@ -150,7 +150,7 @@ packages:
     description:
       name: code_builder
       sha256: "6a6cab2ba4680d6423f34a9b972a4c9a94ebe1b62ecec4e1a1f2cba91fd1319d"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "4.11.1"
   collection:
@@ -158,7 +158,7 @@ packages:
     description:
       name: collection
       sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.19.1"
   convert:
@@ -166,7 +166,7 @@ packages:
     description:
       name: convert
       sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.1.2"
   crypto:
@@ -174,23 +174,23 @@ packages:
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.0.7"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "29f7ecc274a86d32920b1d9cfc7502fa87220da41ec60b55f329559d5732e2b2"
-      url: "https://pub.dev"
+      sha256: "59d53ef8eaed9d288ed9767618e2b31c4fa0383a127db59d5eb2e737a7638a60"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.1.7"
+    version: "3.1.9"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.3.3"
   ffi:
@@ -198,7 +198,7 @@ packages:
     description:
       name: ffi
       sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.2.0"
   file:
@@ -206,7 +206,7 @@ packages:
     description:
       name: file
       sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "7.0.1"
   fixnum:
@@ -214,7 +214,7 @@ packages:
     description:
       name: fixnum
       sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.1.1"
   flutter:
@@ -227,7 +227,7 @@ packages:
     description:
       name: flutter_cache_manager
       sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.4.1"
   flutter_driver:
@@ -240,7 +240,7 @@ packages:
     description:
       name: flutter_highlight
       sha256: "7b96333867aa07e122e245c033b8ad622e4e3a42a1a2372cbb098a2541d8782c"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.7.0"
   flutter_lints:
@@ -248,7 +248,7 @@ packages:
     description:
       name: flutter_lints
       sha256: "5398f14efa795ffb7a33e9b6a08798b26a180edac4ad7db3f231e40f82ce11e1"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "5.0.0"
   flutter_math_fork:
@@ -256,7 +256,7 @@ packages:
     description:
       name: flutter_math_fork
       sha256: "6d5f2f1aa57ae539ffb0a04bb39d2da67af74601d685a161aff7ce5bda5fa407"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.7.4"
   flutter_svg:
@@ -264,7 +264,7 @@ packages:
     description:
       name: flutter_svg
       sha256: "35882981abcbfb8c15b286f0cd690ff25bac12d95eff3e25ee207f37d4c42e7f"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.3.0"
   flutter_test:
@@ -282,7 +282,7 @@ packages:
     description:
       name: glob
       sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.3"
   graphs:
@@ -290,7 +290,7 @@ packages:
     description:
       name: graphs
       sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.3.2"
   highlight:
@@ -298,7 +298,7 @@ packages:
     description:
       name: highlight
       sha256: "5353a83ffe3e3eca7df0abfb72dcf3fa66cc56b953728e7113ad4ad88497cf21"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.7.0"
   hooks:
@@ -306,7 +306,7 @@ packages:
     description:
       name: hooks
       sha256: "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.0.2"
   http:
@@ -314,7 +314,7 @@ packages:
     description:
       name: http
       sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.6.0"
   http_multi_server:
@@ -322,7 +322,7 @@ packages:
     description:
       name: http_multi_server
       sha256: aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.2.2"
   http_parser:
@@ -330,7 +330,7 @@ packages:
     description:
       name: http_parser
       sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "4.1.2"
   integration_test:
@@ -343,7 +343,7 @@ packages:
     description:
       name: io
       sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.0.5"
   jni:
@@ -351,7 +351,7 @@ packages:
     description:
       name: jni
       sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.0.0"
   jni_flutter:
@@ -359,7 +359,7 @@ packages:
     description:
       name: jni_flutter
       sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.0.1"
   json_annotation:
@@ -367,7 +367,7 @@ packages:
     description:
       name: json_annotation
       sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "4.12.0"
   leak_tracker:
@@ -375,7 +375,7 @@ packages:
     description:
       name: leak_tracker
       sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "11.0.2"
   leak_tracker_flutter_testing:
@@ -383,7 +383,7 @@ packages:
     description:
       name: leak_tracker_flutter_testing
       sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.0.10"
   leak_tracker_testing:
@@ -391,7 +391,7 @@ packages:
     description:
       name: leak_tracker_testing
       sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.0.2"
   lints:
@@ -399,7 +399,7 @@ packages:
     description:
       name: lints
       sha256: c35bb79562d980e9a453fc715854e1ed39e24e7d0297a880ef54e17f9874a9d7
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "5.1.1"
   logging:
@@ -407,55 +407,55 @@ packages:
     description:
       name: logging
       sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.3.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
-      url: "https://pub.dev"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
-      url: "https://pub.dev"
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
-      url: "https://pub.dev"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
       name: mime
       sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.0.0"
   mockito:
     dependency: "direct dev"
     description:
       name: mockito
-      sha256: eff30d002f0c8bf073b6f929df4483b543133fcafce056870163587b03f1d422
-      url: "https://pub.dev"
+      sha256: c8d040d754367108fbe482dcb79dd72b8fe60ac6727abd15b4783c5560297ee6
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "5.6.4"
+    version: "5.7.0"
   nested:
     dependency: transitive
     description:
       name: nested
       sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.0.0"
   objective_c:
@@ -463,7 +463,7 @@ packages:
     description:
       name: objective_c
       sha256: "6cb691c686fa2838c6deb34980d426145c2a5d537491cb83d463c33cdbc726ed"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "9.4.1"
   octo_image:
@@ -471,7 +471,7 @@ packages:
     description:
       name: octo_image
       sha256: "34faa6639a78c7e3cbe79be6f9f96535867e879748ade7d17c9b1ae7536293bd"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.0"
   package_config:
@@ -479,7 +479,7 @@ packages:
     description:
       name: package_config
       sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.2.0"
   path:
@@ -487,7 +487,7 @@ packages:
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.9.1"
   path_parsing:
@@ -495,23 +495,23 @@ packages:
     description:
       name: path_parsing
       sha256: "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.1.0"
   path_provider:
     dependency: transitive
     description:
       name: path_provider
-      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
-      url: "https://pub.dev"
+      sha256: a7f4874f987173da295a61c181b8ee71dab59b332a486b391babf26a1b884825
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.5"
+    version: "2.1.6"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
       sha256: "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.3.1"
   path_provider_foundation:
@@ -519,31 +519,31 @@ packages:
     description:
       name: path_provider_foundation
       sha256: "2a376b7d6392d80cd3705782d2caa734ca4727776db0b6ec36ef3f1855197699"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.6.0"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
-      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
-      url: "https://pub.dev"
+      sha256: "58c2005f147315b11e9b4a7bc889cd5203e250cba8e3f012dae259b4972b5c16"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.2"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
-      url: "https://pub.dev"
+      sha256: "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
       sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.3.0"
   petitparser:
@@ -551,7 +551,7 @@ packages:
     description:
       name: petitparser
       sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "7.0.2"
   platform:
@@ -559,7 +559,7 @@ packages:
     description:
       name: platform
       sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.1.6"
   plugin_platform_interface:
@@ -567,7 +567,7 @@ packages:
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.8"
   pool:
@@ -575,7 +575,7 @@ packages:
     description:
       name: pool
       sha256: "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.5.2"
   process:
@@ -583,7 +583,7 @@ packages:
     description:
       name: process
       sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "5.0.5"
   provider:
@@ -591,7 +591,7 @@ packages:
     description:
       name: provider
       sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "6.1.5+1"
   pub_semver:
@@ -599,7 +599,7 @@ packages:
     description:
       name: pub_semver
       sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.2.0"
   pubspec_parse:
@@ -607,7 +607,7 @@ packages:
     description:
       name: pubspec_parse
       sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.5.0"
   record_use:
@@ -615,7 +615,7 @@ packages:
     description:
       name: record_use
       sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.6.0"
   rxdart:
@@ -623,7 +623,7 @@ packages:
     description:
       name: rxdart
       sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.28.0"
   shelf:
@@ -631,7 +631,7 @@ packages:
     description:
       name: shelf
       sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.4.2"
   shelf_web_socket:
@@ -639,7 +639,7 @@ packages:
     description:
       name: shelf_web_socket
       sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.0.0"
   sky_engine:
@@ -652,7 +652,7 @@ packages:
     description:
       name: source_gen
       sha256: ec37cc0e6694374cbef59ed79685572c870a54ede6fa30a3e420feb3adffea02
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "4.2.3"
   source_span:
@@ -660,55 +660,55 @@ packages:
     description:
       name: source_span
       sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.10.2"
   sqflite:
     dependency: transitive
     description:
       name: sqflite
-      sha256: "564cfed0746fe53140c23b70b308e045c3b31f17778f2f326ccb7d804ea0250a"
-      url: "https://pub.dev"
+      sha256: "58a799e6ac17dd32fbab93813d39ed835a75ccc0f8f85b8955fe318c6712b082"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.4.2+1"
+    version: "2.4.3"
   sqflite_android:
     dependency: transitive
     description:
       name: sqflite_android
-      sha256: "881e28efdcc9950fd8e9bb42713dcf1103e62a2e7168f23c9338d82db13dec40"
-      url: "https://pub.dev"
+      sha256: d0548f9d7422a2dae99ec6f8b0a3074463b132d216fa5ba0d230eeefc901983b
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.4.2+3"
+    version: "2.4.3"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "1581ffbf7a0e333b380d6a30737d78516b826cb35beb7fb0bf8a3ea0c678b465"
-      url: "https://pub.dev"
+      sha256: "5bf6a55c166e73bf651ba7ec3ed486e577620e3dc8f3a9c6a258a8031b624590"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.5.8"
+    version: "2.5.11"
   sqflite_darwin:
     dependency: transitive
     description:
       name: sqflite_darwin
-      sha256: "279832e5cde3fe99e8571879498c9211f3ca6391b0d818df4e17d9fff5c6ccb3"
-      url: "https://pub.dev"
+      sha256: c86ca18b8f666bbf903924687fe21cc16fc385d086005067e26619ca530bef9f
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3+1"
   sqflite_platform_interface:
     dependency: transitive
     description:
       name: sqflite_platform_interface
-      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
-      url: "https://pub.dev"
+      sha256: f84939f84350d92d04416f8bc4dc52d3896aec7716cc9e80cf0146342139dc50
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.12.1"
   stream_channel:
@@ -716,7 +716,7 @@ packages:
     description:
       name: stream_channel
       sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.4"
   stream_transform:
@@ -724,7 +724,7 @@ packages:
     description:
       name: stream_transform
       sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.1"
   string_scanner:
@@ -732,7 +732,7 @@ packages:
     description:
       name: string_scanner
       sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.4.1"
   sync_http:
@@ -740,39 +740,39 @@ packages:
     description:
       name: sync_http
       sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.3.1"
   synchronized:
     dependency: transitive
     description:
       name: synchronized
-      sha256: c254ade258ec8282947a0acbbc90b9575b4f19673533ee46f2f6e9b3aeefd7c0
-      url: "https://pub.dev"
+      sha256: "93b153dcb6a26dcddee6ca087dd634b53e38c10b5aa163e8e49501a776456153"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.4.0"
+    version: "3.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
-      url: "https://pub.dev"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   tuple:
     dependency: transitive
     description:
       name: tuple
       sha256: a97ce2013f240b2f3807bcbaf218765b6f301c3eff91092bcfa23a039e7dd151
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.0.2"
   typed_data:
@@ -780,23 +780,23 @@ packages:
     description:
       name: typed_data
       sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.4.0"
   uuid:
     dependency: transitive
     description:
       name: uuid
-      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
-      url: "https://pub.dev"
+      sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "4.5.3"
+    version: "4.6.0"
   vector_graphics:
     dependency: transitive
     description:
       name: vector_graphics
       sha256: "2306c03da2ba81724afeb589c351ebbc0aa7d86005925be8f8735856dbe5e42d"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.2.2"
   vector_graphics_codec:
@@ -804,23 +804,23 @@ packages:
     description:
       name: vector_graphics_codec
       sha256: "99fd9fbd34d9f9a32efd7b6a6aae14125d8237b10403b422a6a6dfeac2806146"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.1.13"
   vector_graphics_compiler:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "7ee12e6dffe0fc8e755179d6d91b3b34f5924223fc104d85572ef9180d73d172"
-      url: "https://pub.dev"
+      sha256: "142a9146f447d15b10bdc00e21d5f4d83e5b32bb5f8f8f5a04c75311344923a3"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.2.5"
+    version: "1.2.6"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.2.0"
   vm_service:
@@ -828,7 +828,7 @@ packages:
     description:
       name: vm_service
       sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "15.2.0"
   watcher:
@@ -836,7 +836,7 @@ packages:
     description:
       name: watcher
       sha256: "1398c9f081a753f9226febe8900fce8f7d0a67163334e1c94a2438339d79d635"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.2.1"
   web:
@@ -844,7 +844,7 @@ packages:
     description:
       name: web
       sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.1.1"
   web_socket:
@@ -852,7 +852,7 @@ packages:
     description:
       name: web_socket
       sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.0.1"
   web_socket_channel:
@@ -860,7 +860,7 @@ packages:
     description:
       name: web_socket_channel
       sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.0.3"
   webdriver:
@@ -868,7 +868,7 @@ packages:
     description:
       name: webdriver
       sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.1.0"
   xdg_directories:
@@ -876,25 +876,25 @@ packages:
     description:
       name: xdg_directories
       sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.1.0"
   xml:
     dependency: transitive
     description:
       name: xml
-      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
-      url: "https://pub.dev"
+      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "6.6.1"
+    version: "7.0.1"
   yaml:
     dependency: transitive
     description:
       name: yaml
       sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.3 <4.0.0"
-  flutter: ">=3.38.4"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_smooth_markdown
 description: High-performance Flutter markdown renderer and editor with syntax highlighting, LaTeX math, tables, footnotes, SVG images, and real-time streaming support.
-version: 0.8.1
+version: 0.9.0
 homepage: https://github.com/JackCaow/flutter-smooth-markdown
 repository: https://github.com/JackCaow/flutter-smooth-markdown
 issue_tracker: https://github.com/JackCaow/flutter-smooth-markdown/issues

--- a/test/integration/html_integration_test.dart
+++ b/test/integration/html_integration_test.dart
@@ -1,0 +1,150 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_smooth_markdown/flutter_smooth_markdown.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Finder findRichTextContaining(String text) {
+    return find.byWidgetPredicate(
+      (widget) =>
+          widget is RichText && widget.text.toPlainText().contains(text),
+    );
+  }
+
+  Widget wrap(Widget child) {
+    return MaterialApp(
+      home: Scaffold(body: SingleChildScrollView(child: child)),
+    );
+  }
+
+  group('SmoothMarkdown HTML integration', () {
+    testWidgets('renders html only when config enables it', (tester) async {
+      const data = 'a <mark>lit</mark> b';
+
+      await tester.pumpWidget(wrap(const SmoothMarkdown(
+        data: data,
+        enableCache: false,
+        useRepaintBoundary: false,
+      )));
+      expect(findRichTextContaining('<mark>lit</mark>'), findsOneWidget);
+
+      await tester.pumpWidget(wrap(const SmoothMarkdown(
+        data: data,
+        config: MarkdownConfig(enableHtml: true),
+        enableCache: false,
+        useRepaintBoundary: false,
+      )));
+      expect(findRichTextContaining('<mark>'), findsNothing);
+      expect(findRichTextContaining('lit'), findsOneWidget);
+    });
+
+    testWidgets('parse cache does not leak results across enableHtml configs',
+        (tester) async {
+      // Unique data so earlier tests cannot have warmed this cache entry.
+      const data = 'cache probe <u>value</u> end';
+
+      // Populate the cache with HTML disabled first.
+      await tester.pumpWidget(wrap(const SmoothMarkdown(
+        data: data,
+        useRepaintBoundary: false,
+      )));
+      expect(findRichTextContaining('<u>value</u>'), findsOneWidget);
+
+      // Same data with HTML enabled must NOT reuse the cached AST.
+      await tester.pumpWidget(wrap(const SmoothMarkdown(
+        data: data,
+        config: MarkdownConfig(enableHtml: true),
+        useRepaintBoundary: false,
+      )));
+      expect(findRichTextContaining('<u>value</u>'), findsNothing);
+      expect(findRichTextContaining('value'), findsOneWidget);
+
+      // And back again: the disabled variant still renders literally.
+      await tester.pumpWidget(wrap(const SmoothMarkdown(
+        data: data,
+        useRepaintBoundary: false,
+      )));
+      expect(findRichTextContaining('<u>value</u>'), findsOneWidget);
+    });
+
+    testWidgets('renders full html feature mix end to end', (tester) async {
+      const data = 'Text <b>b</b> <u>u</u> <sub>2</sub><sup>3</sup> '
+          '<kbd>Ctrl</kbd> <font color="red">r</font><br>next\n\n'
+          '<center>\n\n**centered md**\n\n</center>\n\n'
+          '<blockquote>\nquoted\n</blockquote>\n\n<hr>\n\ndone';
+
+      await tester.pumpWidget(wrap(const SmoothMarkdown(
+        data: data,
+        config: MarkdownConfig(enableHtml: true),
+        enableCache: false,
+        useRepaintBoundary: false,
+      )));
+
+      expect(findRichTextContaining('centered md'), findsOneWidget);
+      expect(findRichTextContaining('quoted'), findsOneWidget);
+      expect(findRichTextContaining('Unknown node type'), findsNothing);
+      expect(find.textContaining('Unknown node type'), findsNothing);
+    });
+
+    testWidgets('selectable mode renders html content without exceptions',
+        (tester) async {
+      const data = '<div align="center">\n<b>bold</b> and <mark>mark</mark>\n'
+          '</div>\n\n<hr>\n\n<kbd>K</kbd>';
+
+      await tester.pumpWidget(wrap(const SmoothMarkdown(
+        data: data,
+        config: MarkdownConfig(enableHtml: true),
+        selectable: true,
+        enableCache: false,
+        useRepaintBoundary: false,
+      )));
+
+      expect(tester.takeException(), isNull);
+      expect(findRichTextContaining('bold'), findsWidgets);
+    });
+  });
+
+  group('StreamMarkdown HTML integration', () {
+    testWidgets('stream markdown renders unclosed bold during streaming',
+        (tester) async {
+      final controller = StreamController<String>();
+      addTearDown(controller.close);
+
+      await tester.pumpWidget(wrap(StreamMarkdown(
+        stream: controller.stream,
+        config: const MarkdownConfig(enableHtml: true),
+      )));
+
+      // First chunk leaves the tag unclosed mid-stream.
+      controller.add('start <b>partial');
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(findRichTextContaining('partial'), findsOneWidget);
+      expect(findRichTextContaining('<b>'), findsNothing);
+
+      // Closing chunk arrives and the same content stays rendered.
+      controller.add(' words</b> tail');
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(findRichTextContaining('partial words'), findsOneWidget);
+      expect(findRichTextContaining('tail'), findsOneWidget);
+    });
+
+    testWidgets('stream markdown grows an unclosed div block', (tester) async {
+      final controller = StreamController<String>();
+      addTearDown(controller.close);
+
+      await tester.pumpWidget(wrap(StreamMarkdown(
+        stream: controller.stream,
+        config: const MarkdownConfig(enableHtml: true),
+      )));
+
+      controller.add('<div>\nfirst line');
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(findRichTextContaining('first line'), findsOneWidget);
+
+      controller.add('\nsecond line\n</div>');
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(findRichTextContaining('second line'), findsOneWidget);
+    });
+  });
+}

--- a/test/integration/html_integration_test.dart
+++ b/test/integration/html_integration_test.dart
@@ -146,5 +146,30 @@ void main() {
       await tester.pump(const Duration(milliseconds: 100));
       expect(findRichTextContaining('second line'), findsOneWidget);
     });
+
+    testWidgets('withholds a partial html tag until it completes',
+        (tester) async {
+      final controller = StreamController<String>();
+      addTearDown(controller.close);
+
+      await tester.pumpWidget(wrap(StreamMarkdown(
+        stream: controller.stream,
+        config: const MarkdownConfig(enableHtml: true),
+      )));
+
+      // First chunk ends mid-tag: `<font colo` has no closing `>`.
+      controller.add('lead <font colo');
+      await tester.pump(const Duration(milliseconds: 100));
+      // The leading text renders, but the partial tag is withheld rather
+      // than flashing as the literal text "<font".
+      expect(findRichTextContaining('lead'), findsOneWidget);
+      expect(findRichTextContaining('<font'), findsNothing);
+
+      // Completing the tag renders the styled content with no literal tag.
+      controller.add('r="red">red</font>');
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(findRichTextContaining('red'), findsOneWidget);
+      expect(findRichTextContaining('<font'), findsNothing);
+    });
   });
 }

--- a/test/parser/details_test.dart
+++ b/test/parser/details_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_smooth_markdown/src/parser/ast/markdown_node.dart';
 import 'package:flutter_smooth_markdown/src/parser/block_parser.dart';
+import 'package:flutter_smooth_markdown/src/parser/markdown_parser.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -186,6 +187,31 @@ Content 2
       expect(json['isOpen'], isTrue);
       expect(json['summary'], isA<List<dynamic>>());
       expect(json['children'], isA<List<dynamic>>());
+    });
+  });
+
+  group('Details inline processing', () {
+    test('processes inline markdown inside details content', () {
+      final parser = MarkdownParser();
+      final nodes = parser.parse(
+        '<details>\n<summary>s</summary>\n**bold** body\n</details>',
+      );
+
+      final details = nodes[0] as DetailsNode;
+      final paragraph = details.children.first as ParagraphNode;
+      expect(paragraph.children.whereType<BoldNode>(), hasLength(1));
+    });
+
+    test('processes nested blocks inside details content', () {
+      final parser = MarkdownParser();
+      final nodes = parser.parse(
+        '<details>\n<summary>s</summary>\n> *quoted*\n</details>',
+      );
+
+      final details = nodes[0] as DetailsNode;
+      final quote = details.children.first as BlockquoteNode;
+      final paragraph = quote.children.first as ParagraphNode;
+      expect(paragraph.children.whereType<ItalicNode>(), hasLength(1));
     });
   });
 }

--- a/test/parser/html_block_parser_test.dart
+++ b/test/parser/html_block_parser_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_smooth_markdown/flutter_smooth_markdown.dart';
+import 'package:flutter_smooth_markdown/src/parser/html/html_block_parser.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('HtmlBlockParser', () {
+    late List<String> parsedSources;
+    late HtmlBlockParser parser;
+
+    setUp(() {
+      parsedSources = <String>[];
+      parser = HtmlBlockParser(
+        parseChildren: (source) {
+          parsedSources.add(source);
+          return <MarkdownNode>[
+            ParagraphNode(<MarkdownNode>[TextNode(source)]),
+          ];
+        },
+      );
+    });
+
+    test('probes standalone hr without treating mid-line html as a block', () {
+      expect(parser.probe('  <hr />  '), isA<HtmlHorizontalRuleMatch>());
+      expect(parser.probe('before <div>x</div>'), isNull);
+      expect(parser.probe('< div>'), isNull);
+    });
+
+    test('probe carries the lexed opening tag into block parsing', () {
+      final match =
+          parser.probe('<div align="right">') as HtmlContainerBlockMatch;
+
+      expect(match.openTag.name, 'div');
+      expect(match.openTag.attributes['align'], 'right');
+      final result = parser.parseBlock(
+        <String>['<div align="right">', 'text', '</div>'],
+        0,
+        match,
+      );
+
+      final node = result.node as HtmlBlockNode;
+      expect(node.align, HtmlBlockAlignment.right);
+      expect(result.linesConsumed, 3);
+      expect(parsedSources, <String>['text']);
+    });
+
+    test('tracks same-name nesting across lines', () {
+      final lines = <String>[
+        '<div>',
+        '<div>',
+        'inner',
+        '</div>',
+        'outer',
+        '</div>',
+      ];
+      final match = parser.probe(lines.first) as HtmlContainerBlockMatch;
+
+      final result = parser.parseBlock(lines, 0, match);
+
+      expect(result.linesConsumed, lines.length);
+      expect(parsedSources.single, contains('<div>'));
+      expect(parsedSources.single, contains('outer'));
+    });
+
+    test('keeps content after the terminating close tag', () {
+      const line = '<div>a</div><div>b</div>';
+      final match = parser.probe(line) as HtmlContainerBlockMatch;
+
+      parser.parseBlock(<String>[line], 0, match);
+
+      expect(parsedSources.single, 'a\n<div>b</div>');
+    });
+
+    test('consumes an incomplete block through input end', () {
+      final lines = <String>['<div>', 'rest', 'more'];
+      final match = parser.probe(lines.first) as HtmlContainerBlockMatch;
+
+      final result = parser.parseBlock(lines, 0, match);
+
+      expect(result.linesConsumed, lines.length);
+      expect(parsedSources.single, 'rest\nmore');
+    });
+
+    test('maps blockquote to the existing markdown node', () {
+      final lines = <String>['<blockquote>', 'quote', '</blockquote>'];
+      final match = parser.probe(lines.first) as HtmlContainerBlockMatch;
+
+      final result = parser.parseBlock(lines, 0, match);
+
+      expect(result.node, isA<BlockquoteNode>());
+    });
+  });
+}

--- a/test/parser/html_block_test.dart
+++ b/test/parser/html_block_test.dart
@@ -1,0 +1,182 @@
+import 'package:flutter_smooth_markdown/flutter_smooth_markdown.dart';
+import 'package:flutter_smooth_markdown/src/parser/block_parser.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('BlockParser HTML support', () {
+    late BlockParser parser;
+
+    setUp(() {
+      parser = BlockParser(enableHtml: true);
+    });
+
+    group('html blocks', () {
+      test('parses center block with children and center alignment', () {
+        final result = parser.parse('<center>\nhello\n</center>');
+        expect(result, hasLength(1));
+        final block = result[0] as HtmlBlockNode;
+        expect(block.tag, 'center');
+        expect(block.align, HtmlBlockAlignment.center);
+        expect(block.children.first, isA<ParagraphNode>());
+      });
+
+      test('parses div with align attribute', () {
+        final result = parser.parse('<div align="right">\ntext\n</div>');
+        final block = result[0] as HtmlBlockNode;
+        expect(block.tag, 'div');
+        expect(block.align, HtmlBlockAlignment.right);
+      });
+
+      test('parses single line p block', () {
+        final result = parser.parse('<p>text</p>');
+        expect(result, hasLength(1));
+        final block = result[0] as HtmlBlockNode;
+        expect(block.tag, 'p');
+        final paragraph = block.children.first as ParagraphNode;
+        expect((paragraph.children.first as TextNode).content, 'text');
+      });
+
+      test('maps html blockquote to BlockquoteNode', () {
+        final result = parser.parse('<blockquote>\nquote\n</blockquote>');
+        expect(result.first, isA<BlockquoteNode>());
+      });
+
+      test('parses markdown content inside html block', () {
+        final result = parser.parse('<div>\n# Title\n- item\n</div>');
+        final block = result[0] as HtmlBlockNode;
+        expect(block.children.whereType<HeaderNode>(), hasLength(1));
+        expect(block.children.whereType<ListNode>(), hasLength(1));
+      });
+
+      test('nested same-tag divs close at matching depth', () {
+        final result = parser.parse(
+          '<div>\n<div>\ninner\n</div>\nouter\n</div>',
+        );
+        expect(result, hasLength(1));
+        final outer = result[0] as HtmlBlockNode;
+        expect(outer.children.whereType<HtmlBlockNode>(), hasLength(1));
+      });
+
+      test('consumes unclosed div to end of input', () {
+        final result = parser.parse('<div>\nrest\nmore');
+        expect(result, hasLength(1));
+        final block = result[0] as HtmlBlockNode;
+        expect(block.children, isNotEmpty);
+      });
+
+      test('keeps remainder after terminating close tag inside block', () {
+        final result = parser.parse('<div>a</div><div>b</div>');
+        expect(result, hasLength(1));
+        final json = result[0].toJson().toString();
+        expect(json, contains('a'));
+        expect(json, contains('b'));
+      });
+
+      test('parses empty self-closed div line', () {
+        final result = parser.parse('<div/>');
+        expect(result, hasLength(1));
+        expect((result[0] as HtmlBlockNode).children, isEmpty);
+      });
+    });
+
+    group('html hr lines', () {
+      test('treats standalone hr tag line as horizontal rule', () {
+        final result = parser.parse('a\n\n<hr>\n\nb');
+        expect(result, hasLength(3));
+        expect(result[1], isA<HorizontalRuleNode>());
+      });
+
+      test('accepts self closing hr variants', () {
+        expect(parser.parse('<hr/>').first, isA<HorizontalRuleNode>());
+        expect(parser.parse('<hr />').first, isA<HorizontalRuleNode>());
+      });
+    });
+
+    group('interaction with other blocks', () {
+      test('paragraph ends when html block line begins', () {
+        final result = parser.parse('text\n<div>\nx\n</div>');
+        expect(result, hasLength(2));
+        expect(result[0], isA<ParagraphNode>());
+        expect(result[1], isA<HtmlBlockNode>());
+      });
+
+      test('details block still parses through dedicated path', () {
+        final result = parser.parse(
+          '<details>\n<summary>s</summary>\nbody\n</details>',
+        );
+        expect(result, hasLength(1));
+        expect(result.first, isA<DetailsNode>());
+      });
+
+      test('mid-line block tag stays part of the paragraph', () {
+        final result = parser.parse('before <div>x</div>');
+        expect(result.first, isA<ParagraphNode>());
+      });
+
+      test('does not treat html block inside fenced code as block', () {
+        final result = parser.parse('```\n<div>\n```');
+        expect(result, hasLength(1));
+        expect(result.first, isA<CodeBlockNode>());
+      });
+    });
+
+    group('html disabled', () {
+      test('leaves div line as paragraph when html disabled', () {
+        final plain = BlockParser();
+        final result = plain.parse('<div>\nx\n</div>');
+        expect(result.whereType<HtmlBlockNode>(), isEmpty);
+        expect(result.first, isA<ParagraphNode>());
+      });
+
+      test('leaves hr tag line as paragraph when html disabled', () {
+        final plain = BlockParser();
+        final result = plain.parse('<hr>');
+        expect(result.first, isA<ParagraphNode>());
+      });
+    });
+  });
+
+  group('MarkdownParser HTML integration', () {
+    test('processes inline markdown inside html block children', () {
+      final parser = MarkdownParser(enableHtml: true);
+      final result = parser.parse('<div>\n**bold** text\n</div>');
+      final block = result[0] as HtmlBlockNode;
+      final paragraph = block.children.first as ParagraphNode;
+      expect(paragraph.children.whereType<BoldNode>(), hasLength(1));
+    });
+
+    test('processes inline html inside regular paragraph', () {
+      final parser = MarkdownParser(enableHtml: true);
+      final result = parser.parse('hello <u>world</u>');
+      final paragraph = result[0] as ParagraphNode;
+      expect(paragraph.children.whereType<UnderlineNode>(), hasLength(1));
+    });
+
+    test('keeps html literal when disabled at parser level', () {
+      final parser = MarkdownParser();
+      final result = parser.parse('hello <u>world</u>');
+      final paragraph = result[0] as ParagraphNode;
+      expect(paragraph.children.whereType<UnderlineNode>(), isEmpty);
+    });
+
+    test('parses inline html inside table cells', () {
+      final parser = MarkdownParser(enableHtml: true);
+      final result = parser.parse(
+        '| a | b |\n| --- | --- |\n| <b>x</b> | y |',
+      );
+      final table = result[0] as TableNode;
+      final firstCell = table.rows.first.cells.first;
+      expect(firstCell.whereType<BoldNode>(), hasLength(1));
+    });
+
+    test('parses inline html inside header lines', () {
+      final parser = MarkdownParser(enableHtml: true);
+      final result = parser.parse('# Title <sup>2</sup>');
+      final header = result[0] as HeaderNode;
+      expect(
+        header.children?.whereType<SuperscriptNode>() ?? const [],
+        hasLength(1),
+      );
+    });
+  });
+}

--- a/test/parser/html_inline_parser_test.dart
+++ b/test/parser/html_inline_parser_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_smooth_markdown/flutter_smooth_markdown.dart';
+import 'package:flutter_smooth_markdown/src/parser/html/html_inline_parser.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  HtmlInlineParser createParser() {
+    return HtmlInlineParser(
+      parseChildren: (source, depth) => [TextNode('$depth:$source')],
+    );
+  }
+
+  group('HtmlInlineParser', () {
+    test('returns null for an invalid tag', () {
+      final result = createParser().tryParse('< b>', 0, 0);
+
+      expect(result, isNull);
+    });
+
+    test('builds bold node and reports the paired tag span', () {
+      final result = createParser().tryParse('<b>x</b>tail', 0, 0)!;
+
+      expect(result.nodes, hasLength(1));
+      final bold = result.nodes.single as BoldNode;
+      expect((bold.children.single as TextNode).content, '1:x');
+      expect(result.consumed, 8);
+    });
+
+    test('splices callback children for unknown tags', () {
+      final result = createParser().tryParse('<video>x</video>', 0, 0)!;
+
+      expect(result.nodes, hasLength(1));
+      expect((result.nodes.single as TextNode).content, '1:x');
+    });
+
+    test('keeps callback children for an unsafe anchor', () {
+      final result = createParser().tryParse(
+        '<a href="javascript:alert(1)">x</a>',
+        0,
+        0,
+      )!;
+
+      expect(result.nodes.whereType<LinkNode>(), isEmpty);
+      expect((result.nodes.single as TextNode).content, '1:x');
+    });
+
+    test('uses image alt text when the image source is unsafe', () {
+      final result = createParser().tryParse(
+        '<img src="javascript:x" alt="fallback">',
+        0,
+        0,
+      )!;
+
+      expect(result.nodes.whereType<ImageNode>(), isEmpty);
+      expect((result.nodes.single as TextNode).content, 'fallback');
+    });
+
+    test('auto-closes an incomplete mark tag at the input end', () {
+      const input = '<mark>partial';
+      final result = createParser().tryParse(input, 0, 0)!;
+
+      expect(result.consumed, input.length);
+      final mark = result.nodes.single as HighlightNode;
+      expect((mark.children.single as TextNode).content, '1:partial');
+    });
+  });
+}

--- a/test/parser/html_inline_test.dart
+++ b/test/parser/html_inline_test.dart
@@ -1,0 +1,273 @@
+import 'package:flutter_smooth_markdown/flutter_smooth_markdown.dart';
+import 'package:flutter_smooth_markdown/src/parser/inline_parser.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('InlineParser HTML support', () {
+    late InlineParser parser;
+
+    setUp(() {
+      parser = InlineParser(enableHtml: true);
+    });
+
+    String plainText(List<MarkdownNode> nodes) =>
+        nodes.whereType<TextNode>().map((n) => n.content).join();
+
+    group('formatting tags', () {
+      test('maps strong tag to BoldNode when html enabled', () {
+        final result = parser.parse('<strong>hi</strong>');
+        expect(result, hasLength(1));
+        expect(result[0], isA<BoldNode>());
+        final bold = result[0] as BoldNode;
+        expect((bold.children.first as TextNode).content, 'hi');
+      });
+
+      test('maps b and i tags to bold and italic nodes', () {
+        expect(parser.parse('<b>x</b>').first, isA<BoldNode>());
+        expect(parser.parse('<i>x</i>').first, isA<ItalicNode>());
+        expect(parser.parse('<em>x</em>').first, isA<ItalicNode>());
+      });
+
+      test('maps strike family tags to StrikethroughNode', () {
+        expect(parser.parse('<s>x</s>').first, isA<StrikethroughNode>());
+        expect(parser.parse('<del>x</del>').first, isA<StrikethroughNode>());
+        expect(
+            parser.parse('<strike>x</strike>').first, isA<StrikethroughNode>());
+      });
+
+      test('maps u and ins tags to UnderlineNode', () {
+        expect(parser.parse('<u>x</u>').first, isA<UnderlineNode>());
+        expect(parser.parse('<ins>x</ins>').first, isA<UnderlineNode>());
+      });
+
+      test('maps mark sub sup and kbd tags to dedicated nodes', () {
+        expect(parser.parse('<mark>x</mark>').first, isA<HighlightNode>());
+        expect(parser.parse('<sub>2</sub>').first, isA<SubscriptNode>());
+        expect(parser.parse('<sup>2</sup>').first, isA<SuperscriptNode>());
+        expect(parser.parse('<kbd>Ctrl</kbd>').first, isA<KbdNode>());
+      });
+
+      test('parses tag names case-insensitively', () {
+        expect(parser.parse('<B>x</B>').first, isA<BoldNode>());
+      });
+
+      test('maps br tag to HardBreakNode', () {
+        final result = parser.parse('a<br>b');
+        expect(result, hasLength(3));
+        expect(result[1], isA<HardBreakNode>());
+        final selfClosed = parser.parse('a<br/>b');
+        expect(selfClosed[1], isA<HardBreakNode>());
+      });
+
+      test('keeps code tag content verbatim without recursion', () {
+        final result = parser.parse('<code>a<b **c**</code>');
+        expect(result, hasLength(1));
+        expect(result[0], isA<InlineCodeNode>());
+        expect((result[0] as InlineCodeNode).code, 'a<b **c**');
+      });
+    });
+
+    group('disabled and literal text', () {
+      test('keeps angle bracket as literal text when html disabled', () {
+        final plain = InlineParser();
+        final result = plain.parse('<b>hi</b>');
+        expect(result, hasLength(1));
+        expect((result[0] as TextNode).content, '<b>hi</b>');
+      });
+
+      test('keeps invalid tags as literal text when html enabled', () {
+        for (final input in ['a < b', '2<3', '<3 you', '< b>', 'end<']) {
+          final result = parser.parse(input);
+          expect(plainText(result), input, reason: 'input: $input');
+        }
+      });
+
+      test('keeps angle bracket autolink style url as literal text', () {
+        final result = parser.parse('<https://example.com>');
+        expect(plainText(result), '<https://example.com>');
+      });
+
+      test('escaped angle bracket suppresses tag parsing', () {
+        final result = parser.parse(r'\<b>x');
+        expect(plainText(result), '<b>x');
+        expect(result.whereType<BoldNode>(), isEmpty);
+      });
+    });
+
+    group('unknown tags', () {
+      test('strips unknown tag and keeps inner content', () {
+        final result = parser.parse('<video>content</video>');
+        expect(result, hasLength(1));
+        expect((result[0] as TextNode).content, 'content');
+      });
+
+      test('strips unknown self-closed tag entirely', () {
+        final result = parser.parse('a<foo/>b');
+        expect(plainText(result), 'ab');
+      });
+
+      test('consumes stray closing tag silently', () {
+        final result = parser.parse('</b>x');
+        expect(plainText(result), 'x');
+      });
+
+      test('consumes inline hr tag silently', () {
+        final result = parser.parse('a<hr>b');
+        expect(plainText(result), 'ab');
+      });
+
+      test('parses markdown inside stripped unknown tag', () {
+        final result = parser.parse('<section>**bold**</section>');
+        expect(result.first, isA<BoldNode>());
+      });
+    });
+
+    group('nesting', () {
+      test('parses nested html tags', () {
+        final result = parser.parse('<b><i>x</i></b>');
+        final bold = result.first as BoldNode;
+        expect(bold.children.first, isA<ItalicNode>());
+      });
+
+      test('matches same-name nested tags with a counter', () {
+        final result = parser.parse('<u>a<u>b</u>c</u>');
+        expect(result, hasLength(1));
+        final outer = result.first as UnderlineNode;
+        expect(outer.children.whereType<UnderlineNode>(), hasLength(1));
+        expect(plainText(outer.children), 'ac');
+      });
+
+      test('parses html inside markdown emphasis', () {
+        final result = parser.parse('**a <u>b</u>**');
+        final bold = result.first as BoldNode;
+        expect(bold.children.whereType<UnderlineNode>(), hasLength(1));
+      });
+
+      test('parses markdown inside html tag', () {
+        final result = parser.parse('<b>a **c**</b>');
+        final bold = result.first as BoldNode;
+        expect(bold.children.whereType<BoldNode>(), hasLength(1));
+      });
+
+      test('falls back to plain text beyond max nesting depth', () {
+        final open = List.filled(20, '<b>').join();
+        final close = List.filled(20, '</b>').join();
+        final result = parser.parse('${open}x$close');
+        expect(result, isNotEmpty);
+      });
+    });
+
+    group('unclosed tags', () {
+      test('auto closes unclosed mark tag at end of text', () {
+        final result = parser.parse('<mark>rest of text');
+        expect(result, hasLength(1));
+        final mark = result.first as HighlightNode;
+        expect(plainText(mark.children), 'rest of text');
+      });
+
+      test('auto closes unclosed unknown tag keeping content', () {
+        final result = parser.parse('<widget>partial');
+        expect(plainText(result), 'partial');
+      });
+    });
+
+    group('code span protection', () {
+      test('does not parse tags inside inline code span', () {
+        final result = parser.parse('`<b>`');
+        expect(result, hasLength(1));
+        expect((result[0] as InlineCodeNode).code, '<b>');
+      });
+
+      test('does not parse tags inside inline math', () {
+        final result = parser.parse(r'$a<b$');
+        expect(result.first, isA<InlineMathNode>());
+      });
+    });
+
+    group('links and images', () {
+      test('parses anchor tag into LinkNode with title', () {
+        final result = parser.parse('<a href="https://x.com" title="t">go</a>');
+        final link = result.first as LinkNode;
+        expect(link.url, 'https://x.com');
+        expect(link.title, 't');
+        expect(plainText(link.children), 'go');
+      });
+
+      test('drops link with javascript href but keeps link text', () {
+        final result = parser.parse('<a href="javascript:alert(1)">click</a>');
+        expect(result.whereType<LinkNode>(), isEmpty);
+        expect(plainText(result), 'click');
+      });
+
+      test('strips anchor without href keeping content', () {
+        final result = parser.parse('<a name="x">y</a>');
+        expect(result.whereType<LinkNode>(), isEmpty);
+        expect(plainText(result), 'y');
+      });
+
+      test('parses img width and height attributes into ImageNode', () {
+        final result = parser.parse(
+          '<img src="https://x.com/a.png" alt="pic" width=64 height="32">',
+        );
+        final image = result.first as ImageNode;
+        expect(image.url, 'https://x.com/a.png');
+        expect(image.alt, 'pic');
+        expect(image.width, 64);
+        expect(image.height, 32);
+      });
+
+      test('emits alt text for img with unsafe src', () {
+        final result = parser.parse('<img src="javascript:x" alt="my pic">');
+        expect(result.whereType<ImageNode>(), isEmpty);
+        expect(plainText(result), 'my pic');
+      });
+
+      test('ignores percent dimensions on img', () {
+        final result = parser.parse(
+          '<img src="https://x.com/a.png" alt="a" width="100%">',
+        );
+        final image = result.first as ImageNode;
+        expect(image.width, isNull);
+      });
+    });
+
+    group('styled spans', () {
+      test('parses font color into StyledSpanNode', () {
+        final result = parser.parse('<font color="red">r</font>');
+        final span = result.first as StyledSpanNode;
+        expect(span.color, 0xFFFF0000);
+      });
+
+      test('parses font size scale into pixels', () {
+        final result = parser.parse('<font size="3">x</font>');
+        final span = result.first as StyledSpanNode;
+        expect(span.fontSize, 16);
+      });
+
+      test('parses span style declarations for safe properties', () {
+        final result = parser.parse(
+          '<span style="color:#00f; font-size:18px; '
+          'background-color:yellow">x</span>',
+        );
+        final span = result.first as StyledSpanNode;
+        expect(span.color, 0xFF0000FF);
+        expect(span.fontSize, 18);
+        expect(span.backgroundColor, 0xFFFFFF00);
+      });
+
+      test('ignores unsafe css properties silently', () {
+        final result = parser.parse(
+          '<span style="position:fixed; color:red">x</span>',
+        );
+        final span = result.first as StyledSpanNode;
+        expect(span.color, 0xFFFF0000);
+      });
+
+      test('strips span without any usable style', () {
+        final result = parser.parse('<span class="x">y</span>');
+        expect(result.whereType<StyledSpanNode>(), isEmpty);
+        expect(plainText(result), 'y');
+      });
+    });
+  });
+}

--- a/test/parser/html_nodes_test.dart
+++ b/test/parser/html_nodes_test.dart
@@ -1,0 +1,160 @@
+import 'package:flutter_smooth_markdown/flutter_smooth_markdown.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('HTML AST Nodes', () {
+    group('UnderlineNode', () {
+      test('exposes children and underline type', () {
+        const node = UnderlineNode([TextNode('under')]);
+        expect(node.children, hasLength(1));
+        expect(node.type, 'underline');
+      });
+
+      test('converts to JSON with children', () {
+        const node = UnderlineNode([TextNode('under')]);
+        final json = node.toJson();
+        expect(json['type'], 'underline');
+        expect(json['children'], hasLength(1));
+      });
+
+      test('copies with new children without mutating original', () {
+        const node = UnderlineNode([TextNode('a')]);
+        final copy = node.copyWith(children: const [TextNode('b')]);
+        expect((copy.children.first as TextNode).content, 'b');
+        expect((node.children.first as TextNode).content, 'a');
+      });
+    });
+
+    group('HighlightNode', () {
+      test('exposes children and highlight type', () {
+        const node = HighlightNode([TextNode('marked')]);
+        expect(node.type, 'highlight');
+        expect(node.toJson()['type'], 'highlight');
+      });
+    });
+
+    group('SubscriptNode', () {
+      test('exposes children and subscript type', () {
+        const node = SubscriptNode([TextNode('2')]);
+        expect(node.type, 'subscript');
+        expect(node.toJson()['children'], hasLength(1));
+      });
+    });
+
+    group('SuperscriptNode', () {
+      test('exposes children and superscript type', () {
+        const node = SuperscriptNode([TextNode('2')]);
+        expect(node.type, 'superscript');
+        expect(node.copyWith().children, hasLength(1));
+      });
+    });
+
+    group('KbdNode', () {
+      test('exposes children and kbd type', () {
+        const node = KbdNode([TextNode('Ctrl')]);
+        expect(node.type, 'kbd');
+        expect(node.toJson()['type'], 'kbd');
+      });
+    });
+
+    group('StyledSpanNode', () {
+      test('stores color, background color, and font size', () {
+        const node = StyledSpanNode(
+          children: [TextNode('styled')],
+          color: 0xFFFF0000,
+          backgroundColor: 0xFF00FF00,
+          fontSize: 18,
+        );
+        expect(node.type, 'styled_span');
+        expect(node.color, 0xFFFF0000);
+        expect(node.backgroundColor, 0xFF00FF00);
+        expect(node.fontSize, 18);
+      });
+
+      test('omits null style fields from JSON', () {
+        const node = StyledSpanNode(children: [TextNode('plain')]);
+        final json = node.toJson();
+        expect(json.containsKey('color'), isFalse);
+        expect(json.containsKey('backgroundColor'), isFalse);
+        expect(json.containsKey('fontSize'), isFalse);
+      });
+
+      test('copies with new color preserving other fields', () {
+        const node = StyledSpanNode(
+          children: [TextNode('styled')],
+          fontSize: 14,
+        );
+        final copy = node.copyWith(color: 0xFF0000FF);
+        expect(copy.color, 0xFF0000FF);
+        expect(copy.fontSize, 14);
+        expect(node.color, isNull);
+      });
+    });
+
+    group('HtmlBlockNode', () {
+      test('stores tag, children, and alignment', () {
+        const node = HtmlBlockNode(
+          tag: 'center',
+          children: [
+            ParagraphNode([TextNode('centered')])
+          ],
+          align: HtmlBlockAlignment.center,
+        );
+        expect(node.type, 'html_block');
+        expect(node.tag, 'center');
+        expect(node.align, HtmlBlockAlignment.center);
+      });
+
+      test('converts to JSON with alignment name', () {
+        const node = HtmlBlockNode(
+          tag: 'div',
+          children: [],
+          align: HtmlBlockAlignment.right,
+        );
+        final json = node.toJson();
+        expect(json['tag'], 'div');
+        expect(json['align'], 'right');
+      });
+
+      test('omits alignment from JSON when null', () {
+        const node = HtmlBlockNode(tag: 'p', children: []);
+        expect(node.toJson().containsKey('align'), isFalse);
+      });
+    });
+
+    group('ImageNode dimensions', () {
+      test('stores optional width and height', () {
+        const node = ImageNode(
+          url: 'https://example.com/a.png',
+          alt: 'alt',
+          width: 200,
+          height: 100,
+        );
+        expect(node.width, 200);
+        expect(node.height, 100);
+      });
+
+      test('defaults width and height to null', () {
+        const node = ImageNode(url: 'a.png', alt: 'alt');
+        expect(node.width, isNull);
+        expect(node.height, isNull);
+        expect(node.toJson().containsKey('width'), isFalse);
+      });
+
+      test('includes dimensions in JSON when present', () {
+        const node = ImageNode(url: 'a.png', alt: 'alt', width: 64);
+        final json = node.toJson();
+        expect(json['width'], 64);
+        expect(json.containsKey('height'), isFalse);
+      });
+
+      test('copies with new dimensions', () {
+        const node = ImageNode(url: 'a.png', alt: 'alt');
+        final copy = node.copyWith(width: 32, height: 16);
+        expect(copy.width, 32);
+        expect(copy.height, 16);
+        expect(copy.url, 'a.png');
+      });
+    });
+  });
+}

--- a/test/parser/html_utils_test.dart
+++ b/test/parser/html_utils_test.dart
@@ -267,4 +267,56 @@ void main() {
       expect(isSafeHtmlUrl('   '), isFalse);
     });
   });
+
+  group('isSafeHtmlImageSrc', () {
+    test('allows http and https urls', () {
+      expect(isSafeHtmlImageSrc('https://example.com'), isTrue);
+      expect(isSafeHtmlImageSrc('http://example.com/a?b=c'), isTrue);
+    });
+
+    test('allows relative and absolute local paths', () {
+      expect(isSafeHtmlImageSrc('assets/img.png'), isTrue);
+      expect(isSafeHtmlImageSrc('/a/b.png'), isTrue);
+      expect(isSafeHtmlImageSrc('icons/logo.svg'), isTrue);
+    });
+
+    test('rejects protocol-relative urls', () {
+      // These would pass isSafeHtmlUrl but cannot be resolved by the
+      // image loaders (no base scheme to inherit), so they must be
+      // rejected here rather than rendering a broken-image fallback.
+      expect(isSafeHtmlImageSrc('//cdn.example.com/x.png'), isFalse);
+      expect(isSafeHtmlImageSrc('////cdn.example.com/x.png'), isFalse);
+    });
+
+    test('rejects mailto and tel schemes', () {
+      expect(isSafeHtmlImageSrc('mailto:a@b.com'), isFalse);
+      expect(isSafeHtmlImageSrc('tel:+12345'), isFalse);
+    });
+
+    test('treats colon after path separator as non-scheme', () {
+      expect(isSafeHtmlImageSrc('a/b:c'), isTrue);
+    });
+
+    test('rejects javascript scheme in image src safety check', () {
+      expect(isSafeHtmlImageSrc('javascript:alert(1)'), isFalse);
+      expect(isSafeHtmlImageSrc('JavaScript:alert(1)'), isFalse);
+    });
+
+    test('rejects javascript scheme hidden by whitespace', () {
+      expect(isSafeHtmlImageSrc('  javascript:alert(1)'), isFalse);
+      expect(isSafeHtmlImageSrc('java\tscript:alert(1)'), isFalse);
+      expect(isSafeHtmlImageSrc('java\nscript:alert(1)'), isFalse);
+    });
+
+    test('rejects data file and vbscript schemes', () {
+      expect(isSafeHtmlImageSrc('data:image/png;base64,AAAA'), isFalse);
+      expect(isSafeHtmlImageSrc('file:///etc/passwd'), isFalse);
+      expect(isSafeHtmlImageSrc('vbscript:x'), isFalse);
+    });
+
+    test('rejects empty url', () {
+      expect(isSafeHtmlImageSrc(''), isFalse);
+      expect(isSafeHtmlImageSrc('   '), isFalse);
+    });
+  });
 }

--- a/test/parser/html_utils_test.dart
+++ b/test/parser/html_utils_test.dart
@@ -185,6 +185,41 @@ void main() {
     });
   });
 
+  group('parseInlineCssDeclarations', () {
+    test('splits declarations and lowercases property names', () {
+      final decls = parseInlineCssDeclarations(
+        'Color: Red; font-size : 14px;',
+      );
+      expect(decls['color'], 'Red');
+      expect(decls['font-size'], '14px');
+    });
+
+    test('skips malformed declarations', () {
+      final decls = parseInlineCssDeclarations('no-colon; :bad; ok:1');
+      expect(decls, {'ok': '1'});
+    });
+
+    test('keeps first value for duplicate properties', () {
+      final decls = parseInlineCssDeclarations('color:red;color:blue');
+      expect(decls['color'], 'red');
+    });
+  });
+
+  group('parseHtmlDimension', () {
+    test('parses bare and px suffixed numbers', () {
+      expect(parseHtmlDimension('64'), 64);
+      expect(parseHtmlDimension('64px'), 64);
+      expect(parseHtmlDimension(' 32.5 '), 32.5);
+    });
+
+    test('rejects percentages zero and oversized values', () {
+      expect(parseHtmlDimension('100%'), isNull);
+      expect(parseHtmlDimension('0'), isNull);
+      expect(parseHtmlDimension('-5'), isNull);
+      expect(parseHtmlDimension('99999'), isNull);
+    });
+  });
+
   group('isSafeHtmlUrl', () {
     test('allows http and https urls', () {
       expect(isSafeHtmlUrl('https://example.com'), isTrue);

--- a/test/parser/html_utils_test.dart
+++ b/test/parser/html_utils_test.dart
@@ -1,0 +1,235 @@
+import 'package:flutter_smooth_markdown/src/parser/html/html_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('lexHtmlTag', () {
+    test('lexes simple open tag', () {
+      final tag = lexHtmlTag('<b>', 0);
+      expect(tag, isNotNull);
+      expect(tag!.name, 'b');
+      expect(tag.isClosing, isFalse);
+      expect(tag.isSelfClosing, isFalse);
+      expect(tag.attributes, isEmpty);
+      expect(tag.end, 3);
+    });
+
+    test('lexes closing tag', () {
+      final tag = lexHtmlTag('</div>', 0);
+      expect(tag!.name, 'div');
+      expect(tag.isClosing, isTrue);
+      expect(tag.end, 6);
+    });
+
+    test('lexes self-closing tag without space', () {
+      final tag = lexHtmlTag('<br/>', 0);
+      expect(tag!.name, 'br');
+      expect(tag.isSelfClosing, isTrue);
+      expect(tag.end, 5);
+    });
+
+    test('lexes self-closing tag with space', () {
+      final tag = lexHtmlTag('<hr />', 0);
+      expect(tag!.name, 'hr');
+      expect(tag.isSelfClosing, isTrue);
+    });
+
+    test('lowercases tag name', () {
+      final tag = lexHtmlTag('<BR>', 0);
+      expect(tag!.name, 'br');
+    });
+
+    test('lexes tag with mixed quoted and unquoted attributes', () {
+      final tag = lexHtmlTag(
+        '<img src="a.png" alt=\'x y\' width=200 loading>',
+        0,
+      );
+      expect(tag!.name, 'img');
+      expect(tag.attributes['src'], 'a.png');
+      expect(tag.attributes['alt'], 'x y');
+      expect(tag.attributes['width'], '200');
+      expect(tag.attributes['loading'], '');
+    });
+
+    test('lowercases attribute names but preserves values', () {
+      final tag = lexHtmlTag('<div ALIGN="Center">', 0);
+      expect(tag!.attributes['align'], 'Center');
+    });
+
+    test('allows spaces around attribute equals sign', () {
+      final tag = lexHtmlTag('<a href = "x">', 0);
+      expect(tag!.attributes['href'], 'x');
+    });
+
+    test('keeps first value for duplicate attributes', () {
+      final tag = lexHtmlTag('<a href="1" href="2">', 0);
+      expect(tag!.attributes['href'], '1');
+    });
+
+    test('allows closing angle bracket inside quoted value', () {
+      final tag = lexHtmlTag('<a title="a > b">', 0);
+      expect(tag!.attributes['title'], 'a > b');
+      expect(tag.end, 17);
+    });
+
+    test('lexes hyphenated custom tag name', () {
+      final tag = lexHtmlTag('<my-widget>', 0);
+      expect(tag!.name, 'my-widget');
+    });
+
+    test('lexes empty unquoted attribute value', () {
+      final tag = lexHtmlTag('<img src=>', 0);
+      expect(tag!.attributes['src'], '');
+    });
+
+    test('lexes at a non-zero start offset', () {
+      final tag = lexHtmlTag('ab<i>', 2);
+      expect(tag!.name, 'i');
+      expect(tag.end, 5);
+    });
+
+    test('returns null for digit after angle bracket', () {
+      expect(lexHtmlTag('<3 you', 0), isNull);
+    });
+
+    test('returns null for space after angle bracket', () {
+      expect(lexHtmlTag('< b>', 0), isNull);
+    });
+
+    test('returns null for tag name starting with digit', () {
+      expect(lexHtmlTag('<1a>', 0), isNull);
+    });
+
+    test('returns null for colon in tag name', () {
+      expect(lexHtmlTag('<https://example.com>', 0), isNull);
+    });
+
+    test('returns null for attribute name starting with digit', () {
+      expect(lexHtmlTag('<a 1x=2>', 0), isNull);
+    });
+
+    test('returns null when closing bracket is missing', () {
+      expect(lexHtmlTag('<b never closed', 0), isNull);
+    });
+
+    test('gives up lexing beyond max tag length', () {
+      final longTag = '<a title="${'x' * 600}">';
+      expect(lexHtmlTag(longTag, 0), isNull);
+    });
+  });
+
+  group('parseHtmlColor', () {
+    test('parses shorthand hex color to argb int', () {
+      expect(parseHtmlColor('#f00'), 0xFFFF0000);
+    });
+
+    test('parses six digit hex color', () {
+      expect(parseHtmlColor('#00FF00'), 0xFF00FF00);
+    });
+
+    test('parses named color case-insensitively', () {
+      expect(parseHtmlColor('red'), 0xFFFF0000);
+      expect(parseHtmlColor('REd'), 0xFFFF0000);
+    });
+
+    test('returns null for unknown color name', () {
+      expect(parseHtmlColor('notacolor'), isNull);
+    });
+
+    test('rejects eight digit hex color', () {
+      expect(parseHtmlColor('#ff00ff00'), isNull);
+    });
+
+    test('rejects malformed hex color', () {
+      expect(parseHtmlColor('#12'), isNull);
+      expect(parseHtmlColor('#gggggg'), isNull);
+      expect(parseHtmlColor(''), isNull);
+    });
+  });
+
+  group('parseHtmlFontSize', () {
+    test('parses pixel value', () {
+      expect(parseHtmlFontSize('18px'), 18);
+    });
+
+    test('converts points to pixels', () {
+      expect(parseHtmlFontSize('12pt'), 16);
+    });
+
+    test('parses bare number', () {
+      expect(parseHtmlFontSize('14'), 14);
+    });
+
+    test('rejects relative units and keywords', () {
+      expect(parseHtmlFontSize('1.2em'), isNull);
+      expect(parseHtmlFontSize('80%'), isNull);
+      expect(parseHtmlFontSize('large'), isNull);
+    });
+
+    test('rejects sizes outside the safe range', () {
+      expect(parseHtmlFontSize('2px'), isNull);
+      expect(parseHtmlFontSize('500px'), isNull);
+    });
+  });
+
+  group('parseFontSizeAttr', () {
+    test('maps legacy font size scale to pixels', () {
+      expect(parseFontSizeAttr('1'), 10);
+      expect(parseFontSizeAttr('3'), 16);
+      expect(parseFontSizeAttr('7'), 48);
+    });
+
+    test('rejects out of range and relative values', () {
+      expect(parseFontSizeAttr('0'), isNull);
+      expect(parseFontSizeAttr('99'), isNull);
+      expect(parseFontSizeAttr('+2'), isNull);
+    });
+  });
+
+  group('isSafeHtmlUrl', () {
+    test('allows http and https urls', () {
+      expect(isSafeHtmlUrl('https://example.com'), isTrue);
+      expect(isSafeHtmlUrl('http://example.com/a?b=c'), isTrue);
+    });
+
+    test('allows mailto and tel schemes', () {
+      expect(isSafeHtmlUrl('mailto:a@b.com'), isTrue);
+      expect(isSafeHtmlUrl('tel:+12345'), isTrue);
+    });
+
+    test('allows relative and anchor urls', () {
+      expect(isSafeHtmlUrl('assets/img.png'), isTrue);
+      expect(isSafeHtmlUrl('/a/b'), isTrue);
+      expect(isSafeHtmlUrl('#section'), isTrue);
+    });
+
+    test('allows protocol-relative urls', () {
+      expect(isSafeHtmlUrl('//cdn.example.com/x.png'), isTrue);
+    });
+
+    test('treats colon after path separator as non-scheme', () {
+      expect(isSafeHtmlUrl('a/b:c'), isTrue);
+    });
+
+    test('rejects javascript scheme in url safety check', () {
+      expect(isSafeHtmlUrl('javascript:alert(1)'), isFalse);
+      expect(isSafeHtmlUrl('JavaScript:alert(1)'), isFalse);
+    });
+
+    test('rejects javascript scheme hidden by whitespace', () {
+      expect(isSafeHtmlUrl('  javascript:alert(1)'), isFalse);
+      expect(isSafeHtmlUrl('java\tscript:alert(1)'), isFalse);
+      expect(isSafeHtmlUrl('java\nscript:alert(1)'), isFalse);
+    });
+
+    test('rejects data file and vbscript schemes', () {
+      expect(isSafeHtmlUrl('data:image/png;base64,AAAA'), isFalse);
+      expect(isSafeHtmlUrl('file:///etc/passwd'), isFalse);
+      expect(isSafeHtmlUrl('vbscript:x'), isFalse);
+    });
+
+    test('rejects empty url', () {
+      expect(isSafeHtmlUrl(''), isFalse);
+      expect(isSafeHtmlUrl('   '), isFalse);
+    });
+  });
+}

--- a/test/performance/html_parse_benchmark_test.dart
+++ b/test/performance/html_parse_benchmark_test.dart
@@ -1,0 +1,163 @@
+import 'package:flutter_smooth_markdown/flutter_smooth_markdown.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Micro-benchmarks for the HTML parsing feature.
+///
+/// These tests print timing numbers for inspection and only assert very
+/// generous bounds so they stay stable on slow CI machines. Run with:
+/// `flutter test test/performance/html_parse_benchmark_test.dart`
+void main() {
+  const warmupIterations = 30;
+  const iterations = 300;
+
+  double benchmark(MarkdownParser parser, String markdown) {
+    for (var i = 0; i < warmupIterations; i++) {
+      parser.parse(markdown);
+    }
+    final stopwatch = Stopwatch()..start();
+    for (var i = 0; i < iterations; i++) {
+      parser.parse(markdown);
+    }
+    stopwatch.stop();
+    return stopwatch.elapsedMicroseconds / iterations;
+  }
+
+  String buildTypicalDocument() {
+    final buffer = StringBuffer();
+    for (var i = 0; i < 40; i++) {
+      buffer
+        ..writeln('## Section $i')
+        ..writeln()
+        ..writeln('Paragraph $i with **bold**, *italic*, `code`, and a '
+            '[link](https://example.com/$i) plus ~~strike~~ text.')
+        ..writeln()
+        ..writeln('- item one for $i')
+        ..writeln('- item two for $i')
+        ..writeln();
+    }
+    return buffer.toString();
+  }
+
+  String buildAngleBracketHeavyDocument() {
+    final buffer = StringBuffer();
+    for (var i = 0; i < 40; i++) {
+      buffer
+        ..writeln('Compare $i: a < b and 2<3 while x > y, generics like '
+            'Map then i < j again, <3 hearts, and trailing < signs <.')
+        ..writeln();
+    }
+    return buffer.toString();
+  }
+
+  String buildHtmlHeavyDocument() {
+    final buffer = StringBuffer();
+    for (var i = 0; i < 40; i++) {
+      buffer
+        ..writeln('Line $i: <b>bold</b> <u>under</u> <mark>mark</mark> '
+            'H<sub>2</sub>O e=mc<sup>2</sup> <kbd>Ctrl</kbd> '
+            '<span style="color:red">red</span><br>next')
+        ..writeln()
+        ..writeln('<div align="center">')
+        ..writeln()
+        ..writeln('block $i content')
+        ..writeln()
+        ..writeln('</div>')
+        ..writeln();
+    }
+    return buffer.toString();
+  }
+
+  group('HTML parsing benchmarks', () {
+    test('flag overhead on typical markdown without html tags', () {
+      final document = buildTypicalDocument();
+      final offTime = benchmark(MarkdownParser(), document);
+      final onTime = benchmark(MarkdownParser(enableHtml: true), document);
+
+      // ignore: avoid_print
+      print('typical doc (${document.length} chars): '
+          'off=${offTime.toStringAsFixed(1)}µs '
+          'on=${onTime.toStringAsFixed(1)}µs '
+          'ratio=${(onTime / offTime).toStringAsFixed(2)}x');
+
+      // Enabling the flag on html-free content must not explode parse
+      // time. Generous bound to avoid CI flakiness.
+      expect(onTime, lessThan(offTime * 3 + 500));
+    });
+
+    test('angle bracket heavy text with html enabled', () {
+      final document = buildAngleBracketHeavyDocument();
+      final offTime = benchmark(MarkdownParser(), document);
+      final onTime = benchmark(MarkdownParser(enableHtml: true), document);
+
+      // ignore: avoid_print
+      print('angle-bracket doc (${document.length} chars): '
+          'off=${offTime.toStringAsFixed(1)}µs '
+          'on=${onTime.toStringAsFixed(1)}µs '
+          'ratio=${(onTime / offTime).toStringAsFixed(2)}x');
+
+      expect(onTime, lessThan(offTime * 5 + 1000));
+    });
+
+    test('html heavy document parse cost', () {
+      final document = buildHtmlHeavyDocument();
+      final onTime = benchmark(MarkdownParser(enableHtml: true), document);
+
+      // ignore: avoid_print
+      print('html-heavy doc (${document.length} chars): '
+          'on=${onTime.toStringAsFixed(1)}µs');
+
+      // Absolute sanity bound only — the feature itself is the cost.
+      expect(onTime, lessThan(50000));
+    });
+
+    test('pathological inputs stay linear-ish', () {
+      final parser = MarkdownParser(enableHtml: true);
+      final cases = <String, String>{
+        'unterminated long tag': '<a href="${'x' * 100000}',
+        'angle bracket spam': 'x<' * 50000,
+        'deep nesting': '${'<b>' * 5000}core${'</b>' * 5000}',
+        'unclosed tag chain': 'a<int> b<int> c<int> ' * 2000,
+      };
+
+      for (final entry in cases.entries) {
+        final stopwatch = Stopwatch()..start();
+        final nodes = parser.parse(entry.value);
+        stopwatch.stop();
+
+        // ignore: avoid_print
+        print('pathological "${entry.key}" '
+            '(${entry.value.length} chars): '
+            '${stopwatch.elapsedMilliseconds}ms');
+
+        expect(nodes, isNotEmpty, reason: entry.key);
+        expect(
+          stopwatch.elapsedMilliseconds,
+          lessThan(2000),
+          reason: 'pathological input must not explode: ${entry.key}',
+        );
+      }
+    });
+
+    test('streaming style incremental re-parse cost', () {
+      final parser = MarkdownParser(enableHtml: true);
+      const chunk = 'streamed <b>bold segment with <u>nested under</u> '
+          'and trailing text ';
+      final buffer = StringBuffer();
+
+      final stopwatch = Stopwatch()..start();
+      for (var i = 0; i < 50; i++) {
+        buffer.write(chunk);
+        // Each tick re-parses the whole accumulated buffer, matching
+        // StreamMarkdown's behavior with unclosed tags mid-stream.
+        parser.parse(buffer.toString());
+      }
+      stopwatch.stop();
+
+      // ignore: avoid_print
+      print('streaming 50 re-parses (final ${buffer.length} chars): '
+          '${stopwatch.elapsedMilliseconds}ms total');
+
+      expect(stopwatch.elapsedMilliseconds, lessThan(5000));
+    });
+  });
+}

--- a/test/renderer/html_builder_test.dart
+++ b/test/renderer/html_builder_test.dart
@@ -191,7 +191,7 @@ void main() {
       expect(find.byType(Align), findsNothing);
     });
 
-    testWidgets('wraps centered blocks in an alignment widget', (tester) async {
+    testWidgets('applies text alignment to centered blocks', (tester) async {
       await tester.pumpWidget(MaterialApp(
         home: builder.build(
           const HtmlBlockNode(
@@ -203,8 +203,12 @@ void main() {
           renderContext,
         ),
       ));
-      expect(find.byType(Align), findsOneWidget);
-      expect(find.byType(IntrinsicWidth), findsOneWidget);
+      expect(find.text('centered'), findsOneWidget);
+      // Alignment is applied at the text level, not via shrink-wrap widgets.
+      expect(find.byType(Align), findsNothing);
+      expect(find.byType(IntrinsicWidth), findsNothing);
+      final text = tester.widget<Text>(find.text('centered'));
+      expect(text.textAlign, TextAlign.center);
     });
   });
 

--- a/test/renderer/html_builder_test.dart
+++ b/test/renderer/html_builder_test.dart
@@ -1,0 +1,282 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_smooth_markdown/flutter_smooth_markdown.dart';
+import 'package:flutter_smooth_markdown/src/renderer/builders/image_builder.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final styleSheet = MarkdownStyleSheet.light();
+  const renderContext = MarkdownRenderContext();
+
+  Finder findRichTextContaining(String text) {
+    return find.byWidgetPredicate(
+      (widget) =>
+          widget is RichText && widget.text.toPlainText().contains(text),
+    );
+  }
+
+  Finder findAnyTextContaining(String text) {
+    return find.byWidgetPredicate(
+      (widget) =>
+          (widget is Text && (widget.data?.contains(text) ?? false)) ||
+          (widget is RichText && widget.text.toPlainText().contains(text)),
+    );
+  }
+
+  group('UnderlineBuilder', () {
+    const builder = UnderlineBuilder();
+
+    test('builds only underline nodes', () {
+      expect(builder.canBuild(const UnderlineNode([TextNode('u')])), isTrue);
+      expect(builder.canBuild(const TextNode('u')), isFalse);
+    });
+
+    testWidgets('applies underline decoration', (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: builder.build(
+          const UnderlineNode([TextNode('under')]),
+          styleSheet,
+          renderContext,
+        ),
+      ));
+      final text = tester.widget<Text>(find.text('under'));
+      expect(text.style?.decoration, TextDecoration.underline);
+    });
+  });
+
+  group('HighlightBuilder', () {
+    const builder = HighlightBuilder();
+
+    test('builds only highlight nodes', () {
+      expect(builder.canBuild(const HighlightNode([TextNode('m')])), isTrue);
+      expect(builder.canBuild(const BoldNode([TextNode('m')])), isFalse);
+    });
+
+    testWidgets('applies background highlight color', (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: builder.build(
+          const HighlightNode([TextNode('marked')]),
+          styleSheet,
+          renderContext,
+        ),
+      ));
+      final text = tester.widget<Text>(find.text('marked'));
+      expect(text.style?.backgroundColor, isNotNull);
+    });
+  });
+
+  group('SubscriptBuilder and SuperscriptBuilder', () {
+    testWidgets('superscript shifts content upward', (tester) async {
+      const builder = SuperscriptBuilder();
+      await tester.pumpWidget(MaterialApp(
+        home: builder.build(
+          const SuperscriptNode([TextNode('2')]),
+          styleSheet,
+          renderContext,
+        ),
+      ));
+      final transform = tester.widget<Transform>(find.byType(Transform));
+      expect(transform.transform.getTranslation().y, lessThan(0));
+    });
+
+    testWidgets('subscript shifts content downward', (tester) async {
+      const builder = SubscriptBuilder();
+      await tester.pumpWidget(MaterialApp(
+        home: builder.build(
+          const SubscriptNode([TextNode('2')]),
+          styleSheet,
+          renderContext,
+        ),
+      ));
+      final transform = tester.widget<Transform>(find.byType(Transform));
+      expect(transform.transform.getTranslation().y, greaterThan(0));
+    });
+
+    testWidgets('scales sub and sup text below base size', (tester) async {
+      const builder = SuperscriptBuilder();
+      await tester.pumpWidget(MaterialApp(
+        home: builder.build(
+          const SuperscriptNode([TextNode('2')]),
+          styleSheet,
+          renderContext,
+        ),
+      ));
+      final text = tester.widget<Text>(find.text('2'));
+      final baseSize = styleSheet.textStyle?.fontSize ?? 16;
+      expect(text.style?.fontSize, lessThan(baseSize));
+    });
+  });
+
+  group('KbdBuilder', () {
+    const builder = KbdBuilder();
+
+    test('builds only kbd nodes', () {
+      expect(builder.canBuild(const KbdNode([TextNode('K')])), isTrue);
+      expect(builder.canBuild(const TextNode('K')), isFalse);
+    });
+
+    testWidgets('renders bordered container around key text', (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: builder.build(
+          const KbdNode([TextNode('Ctrl')]),
+          styleSheet,
+          renderContext,
+        ),
+      ));
+      expect(find.text('Ctrl'), findsOneWidget);
+      final container = tester.widget<Container>(find.byType(Container));
+      final decoration = container.decoration! as BoxDecoration;
+      expect(decoration.border, isNotNull);
+    });
+  });
+
+  group('StyledSpanBuilder', () {
+    const builder = StyledSpanBuilder();
+
+    testWidgets('applies parsed color and font size', (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: builder.build(
+          const StyledSpanNode(
+            children: [TextNode('styled')],
+            color: 0xFFFF0000,
+            fontSize: 20,
+          ),
+          styleSheet,
+          renderContext,
+        ),
+      ));
+      final text = tester.widget<Text>(find.text('styled'));
+      expect(text.style?.color, const Color(0xFFFF0000));
+      expect(text.style?.fontSize, 20);
+    });
+
+    testWidgets('leaves unset style properties null for inheritance',
+        (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: builder.build(
+          const StyledSpanNode(
+            children: [TextNode('styled')],
+            color: 0xFF0000FF,
+          ),
+          styleSheet,
+          renderContext,
+        ),
+      ));
+      final text = tester.widget<Text>(find.text('styled'));
+      expect(text.style?.fontSize, isNull);
+      expect(text.style?.backgroundColor, isNull);
+    });
+  });
+
+  group('HtmlBlockBuilder', () {
+    const builder = HtmlBlockBuilder();
+
+    test('builds only html block nodes', () {
+      expect(
+        builder.canBuild(const HtmlBlockNode(tag: 'div', children: [])),
+        isTrue,
+      );
+      expect(builder.canBuild(const TextNode('x')), isFalse);
+    });
+
+    testWidgets('renders content without alignment wrapper by default',
+        (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: builder.build(
+          const HtmlBlockNode(tag: 'div', children: [TextNode('plain')]),
+          styleSheet,
+          renderContext,
+        ),
+      ));
+      expect(find.text('plain'), findsOneWidget);
+      expect(find.byType(Align), findsNothing);
+    });
+
+    testWidgets('wraps centered blocks in an alignment widget', (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: builder.build(
+          const HtmlBlockNode(
+            tag: 'center',
+            children: [TextNode('centered')],
+            align: HtmlBlockAlignment.center,
+          ),
+          styleSheet,
+          renderContext,
+        ),
+      ));
+      expect(find.byType(Align), findsOneWidget);
+      expect(find.byType(IntrinsicWidth), findsOneWidget);
+    });
+  });
+
+  group('ImageBuilder dimensions', () {
+    testWidgets('constrains size from width and height', (tester) async {
+      const builder = ImageBuilder();
+      await tester.pumpWidget(MaterialApp(
+        home: builder.build(
+          const ImageNode(
+            url: 'assets/missing.png',
+            alt: 'a',
+            width: 64,
+            height: 32,
+          ),
+          styleSheet,
+          renderContext,
+        ),
+      ));
+      final sized = tester.widget<SizedBox>(
+        find.byWidgetPredicate(
+          (widget) => widget is SizedBox && widget.width == 64,
+        ),
+      );
+      expect(sized.height, 32);
+    });
+  });
+
+  group('builder registration coverage', () {
+    const htmlFixture = '<u>u</u> <mark>m</mark> <sub>s</sub> '
+        '<sup>p</sup> <kbd>K</kbd> '
+        '<span style="color:red">c</span> <b>b</b><br>x\n\n'
+        '<center>centered</center>\n\n'
+        '<div align="right">right</div>\n\n'
+        '<hr>';
+
+    Widget wrap(Widget child) {
+      return MaterialApp(
+        home: Scaffold(body: SingleChildScrollView(child: child)),
+      );
+    }
+
+    testWidgets('default registry renders every html node type',
+        (tester) async {
+      await tester.pumpWidget(wrap(const SmoothMarkdown(
+        data: htmlFixture,
+        config: MarkdownConfig(enableHtml: true),
+        enableCache: false,
+        useRepaintBoundary: false,
+      )));
+      expect(findAnyTextContaining('Unknown node type'), findsNothing);
+      expect(findRichTextContaining('centered'), findsOneWidget);
+    });
+
+    testWidgets('enhanced registry renders every html node type',
+        (tester) async {
+      await tester.pumpWidget(wrap(const SmoothMarkdown(
+        data: htmlFixture,
+        config: MarkdownConfig(enableHtml: true),
+        useEnhancedComponents: true,
+        enableCache: false,
+        useRepaintBoundary: false,
+      )));
+      expect(findAnyTextContaining('Unknown node type'), findsNothing);
+    });
+
+    testWidgets('html stays literal without config', (tester) async {
+      await tester.pumpWidget(wrap(const SmoothMarkdown(
+        data: '<mark>m</mark>',
+        enableCache: false,
+        useRepaintBoundary: false,
+      )));
+      expect(findRichTextContaining('<mark>m</mark>'), findsOneWidget);
+    });
+  });
+}

--- a/test/renderer/widget_builder_test.dart
+++ b/test/renderer/widget_builder_test.dart
@@ -601,5 +601,41 @@ void main() {
         expect(registry.findBuilder(node), isNull);
       });
     });
+
+    // Regression guards for a source-breaking change: BlockRenderer is a
+    // public, package-exported typedef, so a plain single-argument
+    // `(nodes) => widget` callback must remain assignable to it. An earlier
+    // revision added a named `context` parameter directly to BlockRenderer,
+    // which made existing callbacks unassignable (invalid_assignment). The
+    // context override now lives on the separate, additive
+    // ContextualBlockRenderer typedef instead.
+    group('BlockRenderer typedef contract', () {
+      Widget oldStyleCallback(List<MarkdownNode> nodes) =>
+          Text(extractPlainText(nodes));
+
+      test('single-argument callback stays assignable to BlockRenderer', () {
+        // Supplying the callback through the `blockRenderer` parameter
+        // forces the assignability check at compile time — if a future
+        // change made a plain `(nodes) => widget` unassignable to
+        // BlockRenderer, this would stop compiling.
+        final context = MarkdownRenderContext(blockRenderer: oldStyleCallback);
+        expect(context.blockRenderer, isNotNull);
+        expect(context.blockRenderer!(const [TextNode('hi')]), isA<Widget>());
+      });
+
+      test('context-aware callback is assignable to BlockRenderer', () {
+        // The renderer exposes one closure through both fields, so a
+        // callback that accepts the optional context must still fit the
+        // single-argument BlockRenderer contract. (The reverse — assigning
+        // a plain single-argument callback to ContextualBlockRenderer — is
+        // intentionally NOT valid, since it could not honor a context
+        // override.)
+        Widget contextAware(List<MarkdownNode> nodes,
+                {MarkdownRenderContext? context}) =>
+            Text(extractPlainText(nodes));
+        final context = MarkdownRenderContext(blockRenderer: contextAware);
+        expect(context.blockRenderer!(const [TextNode('hi')]), isA<Widget>());
+      });
+    });
   });
 }

--- a/test/stream/stream_markdown_test.dart
+++ b/test/stream/stream_markdown_test.dart
@@ -1,8 +1,9 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_smooth_markdown/src/config/markdown_config.dart';
 import 'package:flutter_smooth_markdown/widgets/stream_markdown.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 /// Custom finder that finds RichText widgets containing the specified text
 Finder findRichTextContaining(String text) {
@@ -218,6 +219,103 @@ void main() {
       expect(findRichTextContaining('Header'), findsOneWidget);
       expect(findRichTextContaining('Item 1'), findsOneWidget);
       expect(findRichTextContaining('Item 2'), findsOneWidget);
+    });
+  });
+
+  group('HTML tail withholding', () {
+    testWidgets(
+        'does not swallow partial tag when HTML is disabled (default) '
+        '(regression: `lead <font colo`)', (tester) async {
+      final controller = StreamController<String>();
+      addTearDown(controller.close);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          // No config -> enableHtml defaults to false.
+          home: StreamMarkdown(stream: controller.stream),
+        ),
+      );
+
+      controller.add('lead <font colo');
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // The partial tag is ordinary prose and must render verbatim rather
+      // than being withheld up to the last `<`.
+      expect(findRichTextContaining('lead'), findsOneWidget);
+      expect(findRichTextContaining('font colo'), findsOneWidget);
+    });
+
+    testWidgets(
+        'does not swallow a trailing single `<` when HTML is disabled',
+        (tester) async {
+      final controller = StreamController<String>();
+      addTearDown(controller.close);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StreamMarkdown(stream: controller.stream),
+        ),
+      );
+
+      controller.add('count is 5 <');
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // A bare trailing `<` must not be dropped from the rendered text.
+      expect(findRichTextContaining('5 <'), findsOneWidget);
+    });
+
+    testWidgets(
+        'does not swallow `<` followed by letters in prose when HTML is '
+        'disabled', (tester) async {
+      final controller = StreamController<String>();
+      addTearDown(controller.close);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StreamMarkdown(stream: controller.stream),
+        ),
+      );
+
+      controller.add('see <bold formatting here');
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // Even a `<` directly followed by letters renders as literal prose.
+      expect(findRichTextContaining('<bold'), findsOneWidget);
+      expect(findRichTextContaining('formatting'), findsOneWidget);
+    });
+
+    testWidgets('still withholds a partial tag when HTML is enabled',
+        (tester) async {
+      final controller = StreamController<String>();
+      addTearDown(controller.close);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StreamMarkdown(
+            stream: controller.stream,
+            config: const MarkdownConfig(enableHtml: true),
+          ),
+        ),
+      );
+
+      controller.add('lead <font colo');
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // While the `<font ...` tag is still split across chunks, it is
+      // withheld so the partial tag is not flashed as literal text.
+      expect(findRichTextContaining('font colo'), findsNothing);
+      expect(findRichTextContaining('lead'), findsOneWidget);
+
+      // Complete the tag in the next chunk; now it parses and renders.
+      controller.add('r="red">done</font>');
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(findRichTextContaining('done'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
# Pull Request

  ## Description

  Adds opt-in HTML rendering behind `MarkdownConfig(enableHtml: true)`.

  The implementation supports a safe whitelist of inline and block tags, dedicated AST nodes and renderer builders, configurable
  styles, streaming rendering, and strict URL/style sanitization. HTML remains disabled by default.

  HTML parsing has also been separated into focused inline and block parser modules while preserving existing public APIs, AST output,
  fallback behavior, rendering, and performance characteristics.

  ## Type of Change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] Documentation update
  - [x] Code refactoring
  - [x] Performance improvement
  - [x] Test coverage improvement

  ## Related Issue

  #44 

  ## Changes Made

  - Added opt-in HTML support for inline formatting, links, images, safe styles, block containers, alignment, blockquotes, and
  horizontal rules.
  - Added HTML AST nodes, renderer builders, theme fields, parse-cache isolation, and streaming support.
  - Added URL scheme validation, bounded tag lexing, safe CSS parsing, recursion limits, and fallback handling for malformed or unsafe
  input.
  - Extracted HTML-specific logic into `HtmlInlineParser` and `HtmlBlockParser`, keeping the general Markdown parsers focused on
  precedence and feature gating.
  - Added parser, renderer, integration, streaming, security, performance, and module-level regression tests.
  - Added an interactive HTML example and updated README, CHANGELOG, and HTML documentation.

  ## Testing

  ### Test Configuration

  - Flutter version: 3.44.1
  - Dart version: 3.12.1
  - Platforms tested: [ ] iOS [ ] Android [ ] Web [x] macOS [ ] Windows [ ] Linux

  ### Test Cases

  - HTML-disabled literal fallback and fast path
  - Supported inline and block tags
  - Nested and incomplete HTML tags
  - Unknown-tag child preservation
  - Unsafe link and image URL fallback
  - Safe color, font-size, dimension, and alignment parsing
  - Markdown nested inside HTML
  - Parse-cache isolation between HTML configurations
  - Streaming partial-tag stability
  - Renderer and widget integration
  - Parser performance regression coverage

  ### Verification Results

  - `flutter test --no-pub`: 1027 tests passed
  - HTML-focused test suite: 165 tests passed
  - HTML performance suite: 6 tests passed
  - Changed parser files: `dart analyze` passed with no issues
  - `git diff --check`: passed
  - Full `flutter analyze --no-pub`: reports 262 existing info-level lint findings across the repository; no errors were introduced by
  the changed parser files

  ## Screenshots

  ### Before

  HTML is rendered as literal text when HTML support is disabled.

  ### After

  Whitelisted HTML is rendered when `MarkdownConfig(enableHtml: true)` is enabled. The example application includes toggles for HTML
  rendering and streaming simulation.

  ## Checklist

  ### Code Quality

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] My changes generate no new warnings or errors

  ### Testing

  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [x] `flutter test` passes
  - [ ] `flutter analyze` passes with no issues
  - [ ] `dart format .` has been run

  ### Documentation

  - [x] I have updated the README.md (if applicable)
  - [ ] I have updated the CHANGELOG.md under "Unreleased"
  - [x] I have added/updated dartdoc comments for public APIs
  - [x] I have updated relevant documentation in `/docs` (if applicable)

  ### Breaking Changes

  - [ ] This PR introduces breaking changes
  - [ ] I have updated the migration guide (if breaking changes exist)
  - [ ] I have bumped the version number appropriately

  ## Additional Notes

  - HTML support is disabled by default.
  - Unsupported tags are stripped while retaining their content.
  - Unsafe anchors retain their child text.
  - Unsafe images degrade to alt text or no output.
  - Unclosed tags consume through the current input end for stable streaming renders.
  - The existing `<details>/<summary>` parser path remains unchanged.
  - No public parser, AST, renderer, or configuration contract was removed.

  ## Reviewer Notes

  Please focus on:

  - HTML URL and style sanitization
  - Markdown/HTML parser precedence
  - Unknown, malformed, and incomplete tag fallbacks
  - Streaming behavior for partially received tags
  - Parse-cache isolation between HTML-enabled and disabled configurations
  - The boundary between general Markdown parsers and the new HTML parser modules

  ---

  **For Maintainers:**

  - [ ] Approved by at least one maintainer
  - [ ] CI checks passed
  - [ ] Version bumped (if applicable)
  - [ ] CHANGELOG updated
